### PR TITLE
Add bounds to the minimize optimizer used for ocv fitting

### DIFF
--- a/pyprobe/analysis/base/degradation_mode_analysis_functions.py
+++ b/pyprobe/analysis/base/degradation_mode_analysis_functions.py
@@ -59,7 +59,7 @@ def ocv_curve_fit(
         return np.sum((model - fitting_target_data) ** 2)
 
     if optimizer == "minimize":
-        fitting_result = opt.minimize(cost_function, x_guess)
+        fitting_result = opt.minimize(cost_function, x_guess, bounds=[(0, 1)] * 4)
     elif optimizer == "differential_evolution":
         fitting_result = opt.differential_evolution(
             cost_function, bounds=[(0.75, 0.95), (0.2, 0.3), (0, 0.05), (0.85, 0.95)]

--- a/pyprobe/analysis/degradation_mode_analysis.py
+++ b/pyprobe/analysis/degradation_mode_analysis.py
@@ -42,7 +42,8 @@ class DMA(BaseModel):
     ) -> Tuple[Result, Result]:
         """Fit half cell open circuit potential curves to full cell OCV data.
 
-        Based on the code from :footcite:t:`Kirkaldy_batteryDAT_2023`.
+        Based on the code from :footcite:t:`Kirkaldy_batteryDAT_2023`. The fitting
+        algorithm is based on the scipy.optimize.minimize function.
 
         Args:
             x_ne (NDArray[np.float64]): The anode stoichiometry data.
@@ -50,6 +51,13 @@ class DMA(BaseModel):
             ocp_ne (NDArray[np.float64]): The anode OCP data.
             ocp_pe (NDArray[np.float64]): The cathode OCP data.
             x_guess (NDArray[np.float64]): The initial guess for the fit.
+            fitting_target (str, optional):
+                The target for the curve fitting. Defaults to "OCV".
+            optimizer (str, optional):
+                The optimization algorithm to use. Defaults to None. If None, the
+                optimizer will be set to scipy.optimize.minimize for
+                fitting_target="OCV" and scipy.optimize.differential_evolution for
+                fitting_target="dQdV" or "dVdQ".
 
         Returns:
             Tuple[Result, Result]:


### PR DESCRIPTION
Fix call to `scipy.optimize.minimize` to bound the fitted stoichometry limits between 0 and 1