### PR TITLE
Add options for different compression levels for parquet files

### DIFF
--- a/docs/source/examples/comparing-pyprobe-performance.ipynb
+++ b/docs/source/examples/comparing-pyprobe-performance.ipynb
@@ -324,6 +324,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(np.shape(rep_total_time_pyprobe))\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -344,6 +353,47 @@
     "plt.xlabel('Time [s]')\n",
     "plt.ylabel('Voltage [V]')\n",
     "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Parquet files have a number of options for compression. In PyProBE, two have been selected as options when processing a cycler file. Along with uncompressed, you can prioritise either file size or performance, with performance being the default. The compression options are benchmarked below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compression_priority = [\"performance\", \"file size\", \"uncompressed\"]\n",
+    "\n",
+    "times = np.zeros((len(compression_priority), repeats))\n",
+    "file_sizes = np.zeros((len(compression_priority)))\n",
+    "for i, priority in enumerate(compression_priority):\n",
+    "    cell.process_cycler_file(cycler='neware',\n",
+    "                        folder_path=data_directory,\n",
+    "                        input_filename='sample_data_neware.xlsx',\n",
+    "                        output_filename='sample_data_neware.parquet',\n",
+    "                        compression_priority=priority)\n",
+    "    file_sizes[i] = os.path.getsize(data_directory + f'/sample_data_neware.parquet')\n",
+    "    pyprobe_time, _, _ = measure_pyprobe(repeats, 'sample_data_neware.parquet')\n",
+    "    times[i,:] = pyprobe_time[-1,:]\n",
+    "\n",
+    "file_sizes = np.append(file_sizes, [os.path.getsize(data_directory + f'/sample_data_neware.xlsx'),\n",
+    "                                os.path.getsize(data_directory + f'/sample_data_neware.csv')])\n",
+    "\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "plt.boxplot(times.T, tick_labels=compression_priority, vert=True, patch_artist=True, showfliers=False)\n",
+    "plt.ylabel('Total Read and Filter Time (seconds)')\n",
+    "plt.show()\n",
+    "\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "plt.bar(list(compression_priority+[\"Original - Excel\", \"Original - CSV\"]), file_sizes/10**6)\n",
+    "plt.ylabel('File size (mb)')\n",
+    "plt.show()"
    ]
   }
  ],

--- a/pyprobe/cell.py
+++ b/pyprobe/cell.py
@@ -4,9 +4,8 @@ import os
 import shutil
 import time
 import warnings
-from typing import Callable, Dict, List, Literal, Optional
 import zipfile
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Literal, Optional
 
 import distinctipy
 import polars as pl
@@ -62,10 +61,11 @@ class Cell(BaseModel):
         values = info
         return values
 
-    @validate_call
-    def process_cycler_file(
+    def _convert_to_parquet(
         self,
-        cycler: str,
+        cycler: Literal[
+            "neware", "biologic", "biologic_MB", "arbin", "basytec", "maccor", "generic"
+        ],
         folder_path: str,
         input_filename: str | Callable[[str], str],
         output_filename: str | Callable[[str], str],
@@ -74,36 +74,40 @@ class Cell(BaseModel):
             "performance", "file size", "uncompressed"
         ] = "performance",
         overwrite_existing: bool = False,
+        column_dict: Optional[Dict[str, str]] = None,
     ) -> None:
-        """Convert cycler file into PyProBE format.
+        """Convert a file into PyProBE format.
 
         Args:
-            cycler (str):
-                The cycler used to produce the data. Available cyclers are:
-                - 'neware'
-                - 'biologic'
-                - 'biologic_MB' (for Modulo Bat Biologic data)
-            folder_path (str):
+            cycler:
+                The cycler used to produce the data.
+            folder_path:
                 The path to the folder containing the data file.
-            input_filename (str | function):
+            input_filename:
                 A filename string or a function to generate the file name for cycler
                 data.
-            output_filename (str | function):
+            output_filename:
                 A filename string or a function to generate the file name for PyProBE
                 data.
-            filename_inputs (list):
+            filename_inputs:
                 The list of inputs to input_filename and output_filename, if they are
                 functions. These must be keys of the cell info.
-            compression_priority (str):
+            compression_priority:
                 The priority of the compression algorithm to use on the resulting
                 parquet file. Available options are:
                 - 'performance': Use the 'lz4' compression algorithm (default).
                 - 'file size': Use the 'zstd' compression algorithm.
                 - 'uncompressed': Do not use compression.
-            overwrite_existing (bool):
+            overwrite_existing:
                 If True, any existing parquet file with the output_filename will be
                 overwritten. If False, the function will skip the conversion if the
                 parquet file already exists.
+            column_dict:
+                A dictionary mapping the column names in the cycler file to the PyProBE
+                column names. The keys of the dictionary are the cycler column names and
+                the values are the PyProBE column names. You must use asterisks to
+                indicate the units of the columns. Only used for the 'generic' cycler.
+                E.g. :code:`{"V (*)": "Voltage [*]"}`.
         """
         input_data_path = self._get_data_paths(
             folder_path, input_filename, filename_inputs
@@ -120,9 +124,22 @@ class Cell(BaseModel):
                 "neware": neware.Neware,
                 "biologic": biologic.Biologic,
                 "biologic_MB": biologic.BiologicMB,
+                "arbin": arbin.Arbin,
+                "basytec": basytec.Basytec,
+                "maccor": maccor.Maccor,
             }
             t1 = time.time()
-            importer = cycler_dict[cycler](input_data_path=input_data_path)
+            if cycler == "generic":
+                if column_dict is None:
+                    raise ValueError(
+                        "column_dict must be provided for the generic cycler."
+                    )
+                importer = basecycler.BaseCycler(
+                    input_data_path=input_data_path,
+                    column_dict=column_dict,
+                )
+            else:
+                importer = cycler_dict[cycler](input_data_path=input_data_path)
             compression_dict = {
                 "uncompressed": "uncompressed",
                 "performance": "lz4",
@@ -136,6 +153,58 @@ class Cell(BaseModel):
             print(f"\tparquet written in {time.time()-t1: .2f} seconds.")
         else:
             print(f"File {output_data_path} already exists. Skipping.")
+
+    @validate_call
+    def process_cycler_file(
+        self,
+        cycler: Literal[
+            "neware", "biologic", "biologic_MB", "arbin", "basytec", "maccor", "generic"
+        ],
+        folder_path: str,
+        input_filename: str | Callable[[str], str],
+        output_filename: str | Callable[[str], str],
+        filename_inputs: Optional[List[str]] = None,
+        compression_priority: Literal[
+            "performance", "file size", "uncompressed"
+        ] = "performance",
+        overwrite_existing: bool = False,
+    ) -> None:
+        """Convert a file into PyProBE format.
+
+        Args:
+            cycler:
+                The cycler used to produce the data.
+            folder_path:
+                The path to the folder containing the data file.
+            input_filename:
+                A filename string or a function to generate the file name for cycler
+                data.
+            output_filename:
+                A filename string or a function to generate the file name for PyProBE
+                data.
+            filename_inputs:
+                The list of inputs to input_filename and output_filename, if they are
+                functions. These must be keys of the cell info.
+            compression_priority:
+                The priority of the compression algorithm to use on the resulting
+                parquet file. Available options are:
+                - 'performance': Use the 'lz4' compression algorithm (default).
+                - 'file size': Use the 'zstd' compression algorithm.
+                - 'uncompressed': Do not use compression.
+            overwrite_existing:
+                If True, any existing parquet file with the output_filename will be
+                overwritten. If False, the function will skip the conversion if the
+                parquet file already exists.
+        """
+        self._convert_to_parquet(
+            cycler,
+            folder_path,
+            input_filename,
+            output_filename,
+            filename_inputs,
+            compression_priority,
+            overwrite_existing,
+        )
 
     @validate_call
     def process_generic_file(
@@ -169,39 +238,22 @@ class Cell(BaseModel):
             filename_inputs (list):
                 The list of inputs to input_filename and output_filename.
                 These must be keys of the cell info.
-            compression_priority (str):
+            compression_priority:
                 The priority of the compression algorithm to use on the resulting
                 parquet file. Available options are:
                 - 'performance': Use the 'lz4' compression algorithm (default).
                 - 'file size': Use the 'zstd' compression algorithm.
                 - 'uncompressed': Do not use compression.
         """
-        input_data_path = self._get_data_paths(
-            folder_path, input_filename, filename_inputs
-        )
-        output_data_path = self._get_data_paths(
-            folder_path, output_filename, filename_inputs
-        )
-        output_data_path = self._verify_parquet(output_data_path)
-        if "*" in output_data_path:
-            raise ValueError("* characters are not allowed for a complete data path")
-
-        t1 = time.time()
-        importer = basecycler.BaseCycler(
-            input_data_path=input_data_path,
+        self._convert_to_parquet(
+            "generic",
+            folder_path,
+            input_filename,
+            output_filename,
+            filename_inputs,
+            compression_priority,
             column_dict=column_dict,
         )
-        compression_dict = {
-            "uncompressed": "uncompressed",
-            "performance": "lz4",
-            "file size": "zstd",
-        }
-        self._write_parquet(
-            importer,
-            output_data_path,
-            compression=compression_dict[compression_priority],
-        )
-        print(f"\tparquet written in {time.time()-t1: .2f} seconds.")
 
     @validate_call
     def add_procedure(

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -73,7 +73,14 @@ def test_process_cycler_file(cell_instance, lazyframe_fixture):
     folder_path = "tests/sample_data/neware/"
     file_name = "sample_data_neware.xlsx"
     output_name = "sample_data_neware.parquet"
-    cell_instance.process_cycler_file("neware", folder_path, file_name, output_name)
+    cell_instance.process_cycler_file(
+        "neware",
+        folder_path,
+        file_name,
+        output_name,
+        compression_priority="file size",
+        overwrite_existing=True,
+    )
     expected_dataframe = lazyframe_fixture.collect()
     expected_dataframe = expected_dataframe.with_columns(
         pl.col("Date").dt.cast_time_unit("us")


### PR DESCRIPTION
This pull request includes several changes to the `pyprobe` project, focusing on adding new functionality for compression options and refactoring the code to improve clarity and maintainability.

### New Functionality:
* Added support for different compression priorities (`performance`, `file size`, `uncompressed`) when converting files to PyProBE format. (`[[1]](diffhunk://#diff-441aec132d927ef70cd9824112874874d1fb11d9d8bc0604c3b492ed3ad9a7c8L64-R110)`, `[[2]](diffhunk://#diff-441aec132d927ef70cd9824112874874d1fb11d9d8bc0604c3b492ed3ad9a7c8R122-R207)`, `[[3]](diffhunk://#diff-441aec132d927ef70cd9824112874874d1fb11d9d8bc0604c3b492ed3ad9a7c8R217-R219)`, `[[4]](diffhunk://#diff-441aec132d927ef70cd9824112874874d1fb11d9d8bc0604c3b492ed3ad9a7c8R241-L162)`)
* Updated the `process_cycler_file` and `process_generic_file` methods to include the `compression_priority` parameter. (`[[1]](diffhunk://#diff-441aec132d927ef70cd9824112874874d1fb11d9d8bc0604c3b492ed3ad9a7c8L64-R110)`, `[[2]](diffhunk://#diff-441aec132d927ef70cd9824112874874d1fb11d9d8bc0604c3b492ed3ad9a7c8R217-R219)`)
* Add the functionality to skip re-generation of parquet files if they already exist

### Code Refactoring:
* Extracted the file conversion logic into a new private method `_convert_to_parquet` to simplify the `process_cycler_file` and `process_generic_file` methods. (`[[1]](diffhunk://#diff-441aec132d927ef70cd9824112874874d1fb11d9d8bc0604c3b492ed3ad9a7c8L64-R110)`, `[[2]](diffhunk://#diff-441aec132d927ef70cd9824112874874d1fb11d9d8bc0604c3b492ed3ad9a7c8R217-R219)`)
* Modified the `_write_parquet` method to accept a `compression` parameter and use it when writing the parquet file. (`[pyprobe/cell.pyR323-R335](diffhunk://#diff-441aec132d927ef70cd9824112874874d1fb11d9d8bc0604c3b492ed3ad9a7c8R323-R335)`)

### Documentation and Examples:
* Added new code cells and markdown explanations to the `comparing-pyprobe-performance.ipynb` notebook to demonstrate the new compression options and their performance. (`[[1]](diffhunk://#diff-f97df501eeb86d9944940d597c2c80a87b666e5ecd0715eb1cd37238964dc9e1R326-R334)`, `[[2]](diffhunk://#diff-f97df501eeb86d9944940d597c2c80a87b666e5ecd0715eb1cd37238964dc9e1R357-R397)`)

### Testing:
* Updated the `test_process_cycler_file` test case to include the `compression_priority` and `overwrite_existing` parameters. (`[tests/test_cell.pyL76-R83](diffhunk://#diff-5f57142fa1c2be045e3012de7f735da962b090fe45c8957a3deef79bb4819677L76-R83)`)