### PR TITLE
Fix bug where upper case .CSV file not read

### DIFF
--- a/pyprobe/cyclers/basecycler.py
+++ b/pyprobe/cyclers/basecycler.py
@@ -158,7 +158,7 @@ class BaseCycler(BaseModel):
         """
         file = os.path.basename(filepath)
         file_ext = os.path.splitext(file)[1]
-        match file_ext:
+        match file_ext.lower():
             case ".xlsx":
                 return pl.read_excel(filepath, engine="calamine", infer_schema_length=0)
             case ".csv":


### PR DESCRIPTION
This pull request includes a small but important change to the `read_file` function in the `pyprobe/cyclers/basecycler.py` file. The change ensures that file extensions are handled in a case-insensitive manner.

* [`pyprobe/cyclers/basecycler.py`](diffhunk://#diff-fb018c144804be12e36facbe6465c3e28413496785903af39a0073e3ffbd3a57L161-R161): Modified the `read_file` function to use `file_ext.lower()` in the `match` statement to handle file extensions in a case-insensitive manner.