### PR TITLE
Allow dict as info field

### DIFF
--- a/pyprobe/cell.py
+++ b/pyprobe/cell.py
@@ -5,7 +5,7 @@ import shutil
 import time
 import warnings
 import zipfile
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import distinctipy
 import polars as pl
@@ -22,7 +22,7 @@ __version__ = "1.0.3"
 class Cell(BaseModel):
     """A class for a cell in a battery experiment."""
 
-    info: Dict[str, Optional[str | int | float]]
+    info: Dict[str, Optional[str | int | float | Dict[Any, Any]]]
     """Dictionary containing information about the cell.
     The dictionary must contain a 'Name' field, other information may include
     channel number or other rig information.
@@ -32,8 +32,8 @@ class Cell(BaseModel):
 
     @field_validator("info")
     def check_and_set_name(
-        cls, info: Dict[str, Optional[str | int | float]]
-    ) -> Dict[str, Optional[str | int | float]]:
+        cls, info: Dict[str, Optional[str | int | float | Dict[Any, Any]]]
+    ) -> Dict[str, Optional[str | int | float | Dict[Any, Any]]]:
         """Validate the `info` field.
 
         Checks that a `Name` field is present in the `info` dictionary, if not it is
@@ -240,7 +240,7 @@ class Cell(BaseModel):
 
     @staticmethod
     def _get_filename(
-        info: Dict[str, Optional[str | int | float]],
+        info: Dict[str, Optional[str | int | float | Dict[Any, Any]]],
         filename_function: Callable[[str], str],
         filename_inputs: List[str],
     ) -> str:

--- a/pyprobe/filters.py
+++ b/pyprobe/filters.py
@@ -4,10 +4,9 @@ import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 import polars as pl
-from pydantic import Field
 
 from pyprobe import utils
-from pyprobe.rawdata import RawData, default_column_definitions
+from pyprobe.rawdata import RawData
 
 if TYPE_CHECKING:
     from pyprobe.typing import (  # , FilterToStepType
@@ -277,14 +276,14 @@ class Procedure(RawData):
     """A class for a procedure in a battery experiment."""
 
     readme_dict: Dict[str, Dict[str, List[str | int | Tuple[int, int, int]]]]
+    """A dictionary representing the data contained in the README yaml file."""
 
-    base_dataframe: pl.LazyFrame | pl.DataFrame
-    info: Dict[str, Optional[str | int | float]]
-    column_definitions: Dict[str, str] = Field(
-        default_factory=lambda: default_column_definitions.copy()
-    )
-    step_descriptions: Dict[str, List[Optional[str | int]]] = {}
     cycle_info: List[Tuple[int, int, int]] = []
+    """A list of tuples representing the cycle information from the README yaml file.
+
+    The tuple format is
+    :code:`(start step (inclusive), end step (inclusive), cycle count)`.
+    """
 
     def model_post_init(self, __context: Any) -> None:
         """Create a procedure class."""
@@ -449,12 +448,12 @@ class Procedure(RawData):
 class Experiment(RawData):
     """A class for an experiment in a battery experimental procedure."""
 
-    base_dataframe: pl.LazyFrame | pl.DataFrame
-    info: Dict[str, Optional[str | int | float]]
-    column_definitions: Dict[str, str] = Field(
-        default_factory=lambda: default_column_definitions.copy()
-    )
-    cycle_info: List[Tuple[int, int, int]]
+    cycle_info: List[Tuple[int, int, int]] = []
+    """A list of tuples representing the cycle information from the README yaml file.
+
+    The tuple format is
+    :code:`(start step (inclusive), end step (inclusive), cycle count)`.
+    """
 
     def model_post_init(self, __context: Any) -> None:
         """Create an experiment class."""
@@ -483,12 +482,12 @@ class Experiment(RawData):
 class Cycle(RawData):
     """A class for a cycle in a battery experimental procedure."""
 
-    base_dataframe: pl.LazyFrame | pl.DataFrame
-    info: Dict[str, Optional[str | int | float]]
-    column_definitions: Dict[str, str] = Field(
-        default_factory=lambda: default_column_definitions.copy()
-    )
-    cycle_info: List[Tuple[int, int, int]]
+    cycle_info: List[Tuple[int, int, int]] = []
+    """A list of tuples representing the cycle information from the README yaml file.
+
+    The tuple format is
+    :code:`(start step (inclusive), end step (inclusive), cycle count)`.
+    """
 
     def model_post_init(self, __context: Any) -> None:
         """Create a cycle class."""
@@ -515,12 +514,6 @@ class Cycle(RawData):
 
 class Step(RawData):
     """A class for a step in a battery experimental procedure."""
-
-    base_dataframe: pl.LazyFrame | pl.DataFrame
-    info: Dict[str, Optional[str | int | float]]
-    column_definitions: Dict[str, str] = Field(
-        default_factory=lambda: default_column_definitions.copy()
-    )
 
     def model_post_init(self, __context: Any) -> None:
         """Create a step class."""

--- a/pyprobe/rawdata.py
+++ b/pyprobe/rawdata.py
@@ -50,12 +50,15 @@ class RawData(Result):
     This defines the PyProBE format.
     """
 
-    base_dataframe: pl.LazyFrame | pl.DataFrame
-    info: Dict[str, Optional[str | int | float]]
     column_definitions: Dict[str, str] = Field(
         default_factory=lambda: default_column_definitions.copy()
     )
     step_descriptions: Dict[str, List[Optional[str | int]]] = {}
+    """A dictionary containing the fields 'Step' and 'Description'.
+
+    - 'Step' is a list of step numbers.
+    - 'Description' is a list of corresponding descriptions in PyBaMM Experiment format.
+    """
 
     @field_validator("base_dataframe")
     @classmethod

--- a/pyprobe/result.py
+++ b/pyprobe/result.py
@@ -35,7 +35,7 @@ class Result(BaseModel):
 
     base_dataframe: Union[pl.LazyFrame, pl.DataFrame]
     """The data as a polars DataFrame or LazyFrame."""
-    info: Dict[str, Optional[str | int | float]]
+    info: Dict[str, Optional[str | int | float | Dict[Any, Any]]]
     """Dictionary containing information about the cell."""
     column_definitions: Dict[str, str] = Field(default_factory=dict)
     """A dictionary containing the definitions of the columns in the data."""
@@ -364,7 +364,7 @@ class Result(BaseModel):
                 | Dict[str, NDArray[np.float64] | List[float]]
             ]
         ],
-        info: Dict[str, Optional[str | int | float]],
+        info: Dict[str, Optional[str | int | float | Dict[Any, Any]]],
     ) -> "Result":
         """Build a Result object from a list of dataframes.
 


### PR DESCRIPTION
This pull request includes several changes to the `pyprobe` package, primarily focusing on enhancing type annotations and simplifying class structures. The most important changes involve updating the `info` field to support nested dictionaries and removing re-definitions of inherited attributes from multiple classes.

### Type Annotations and Field Updates:

* [`pyprobe/cell.py`](diffhunk://#diff-441aec132d927ef70cd9824112874874d1fb11d9d8bc0604c3b492ed3ad9a7c8L25-R25): Updated the `info` field in the `Cell` class to support nested dictionaries. This change is reflected in the type annotations and the corresponding field validator. [[1]](diffhunk://#diff-441aec132d927ef70cd9824112874874d1fb11d9d8bc0604c3b492ed3ad9a7c8L25-R25) [[2]](diffhunk://#diff-441aec132d927ef70cd9824112874874d1fb11d9d8bc0604c3b492ed3ad9a7c8L35-R36) [[3]](diffhunk://#diff-441aec132d927ef70cd9824112874874d1fb11d9d8bc0604c3b492ed3ad9a7c8L243-R243)

### Codebase Simplification:

* [`pyprobe/filters.py`](diffhunk://#diff-29af473657568b27fc4bcf5bd3262cca89dbce74f91077720bdbc60eb73ec795R279-R286): Removed inherited attributes such as `base_dataframe`, `info`, and `column_definitions` from multiple classes (`Procedure`, `Experiment`, `Cycle`, `Step`). This helps in simplifying the class definitions and reducing clutter. [[1]](diffhunk://#diff-29af473657568b27fc4bcf5bd3262cca89dbce74f91077720bdbc60eb73ec795R279-R286) [[2]](diffhunk://#diff-29af473657568b27fc4bcf5bd3262cca89dbce74f91077720bdbc60eb73ec795L452-R456) [[3]](diffhunk://#diff-29af473657568b27fc4bcf5bd3262cca89dbce74f91077720bdbc60eb73ec795L486-R490) [[4]](diffhunk://#diff-29af473657568b27fc4bcf5bd3262cca89dbce74f91077720bdbc60eb73ec795L519-L524)
* [`pyprobe/rawdata.py`](diffhunk://#diff-0f869473df08c774f283bd2f94008e8cf0b4277d6b1049f0ece499d691a10f53L53-R61): Removed the `base_dataframe` and `info` attributes from the `RawData` class and added a detailed docstring for the `step_descriptions` attribute.

### Additional Changes:

* [`pyprobe/result.py`](diffhunk://#diff-f6271fc55361775ee0d28df48b7f18a4ac1dfc4ba9e2e3005a512f807baca9b5L38-R38): Updated the `info` field in the `Result` class to support nested dictionaries and adjusted the type annotations accordingly. [[1]](diffhunk://#diff-f6271fc55361775ee0d28df48b7f18a4ac1dfc4ba9e2e3005a512f807baca9b5L38-R38) [[2]](diffhunk://#diff-f6271fc55361775ee0d28df48b7f18a4ac1dfc4ba9e2e3005a512f807baca9b5L367-R367)
* [`pyprobe/filters.py`](diffhunk://#diff-29af473657568b27fc4bcf5bd3262cca89dbce74f91077720bdbc60eb73ec795L7-R9): Removed the import of `Field` from `pydantic` as it is no longer needed.