### PR TITLE
Fix multi file reading where columns are missing in some files

### DIFF
--- a/pyprobe/cyclers/basecycler.py
+++ b/pyprobe/cyclers/basecycler.py
@@ -179,16 +179,13 @@ class BaseCycler(BaseModel):
         files.sort()
         list = [self.read_file(file) for file in files]
         all_columns = set([col for df in list for col in df.collect_schema().names()])
-        indices_to_remove = []
         for i in range(len(list)):
             if len(list[i].collect_schema().names()) < len(all_columns):
-                indices_to_remove.append(i)
                 warnings.warn(
                     f"File {os.path.basename(files[i])} has missing columns, "
-                    "it has not been read."
+                    "these have been filled with null values."
                 )
-                continue
-        return [df for i, df in enumerate(list) if i not in indices_to_remove]
+        return list
 
     def get_imported_dataframe(
         self, dataframe_list: List[pl.DataFrame]

--- a/pyprobe/cyclers/basecycler.py
+++ b/pyprobe/cyclers/basecycler.py
@@ -201,7 +201,7 @@ class BaseCycler(BaseModel):
         Returns:
             DataFrame: A single DataFrame.
         """
-        return pl.concat(dataframe_list, how="vertical", rechunk=True)
+        return pl.concat(dataframe_list, how="diagonal", rechunk=True)
 
     @staticmethod
     def _match_unit(column_name: str, pattern: str) -> Optional[str]:

--- a/pyprobe/cyclers/biologic.py
+++ b/pyprobe/cyclers/biologic.py
@@ -1,7 +1,6 @@
 """A module to load and process Biologic battery cycler data."""
 
 
-import glob
 from datetime import datetime
 from typing import List
 
@@ -116,17 +115,3 @@ class BiologicMB(Biologic):
         return df_with_max_step.with_columns(
             pl.col("Ns").cast(pl.Int64) + pl.col("Max_Step")
         )
-
-    def _get_dataframe_list(self) -> list[pl.DataFrame | pl.LazyFrame]:
-        """Return a list of all the imported dataframes.
-
-        Args:
-            input_data_path (str): The path to the input data.
-
-        Returns:
-            List[DataFrame]: A list of DataFrames.
-        """
-        files = glob.glob(self.input_data_path)
-        files.sort()
-        list = [self.read_file(file) for file in files]
-        return list

--- a/pyprobe/cyclers/biologic.py
+++ b/pyprobe/cyclers/biologic.py
@@ -1,6 +1,7 @@
 """A module to load and process Biologic battery cycler data."""
 
 
+import glob
 from datetime import datetime
 from typing import List
 
@@ -115,3 +116,17 @@ class BiologicMB(Biologic):
         return df_with_max_step.with_columns(
             pl.col("Ns").cast(pl.Int64) + pl.col("Max_Step")
         )
+
+    def _get_dataframe_list(self) -> list[pl.DataFrame | pl.LazyFrame]:
+        """Return a list of all the imported dataframes.
+
+        Args:
+            input_data_path (str): The path to the input data.
+
+        Returns:
+            List[DataFrame]: A list of DataFrames.
+        """
+        files = glob.glob(self.input_data_path)
+        files.sort()
+        list = [self.read_file(file) for file in files]
+        return list


### PR DESCRIPTION
This pull request includes several changes to the `pyprobe/cyclers/basecycler.py` file and its corresponding test file. The changes focus on improving the handling of dataframes with missing columns and updating the concatenation method for dataframes. Additionally, a new test case has been added to verify the handling of missing columns.

### Changes to dataframe handling:

* [`pyprobe/cyclers/basecycler.py`](diffhunk://#diff-fb018c144804be12e36facbe6465c3e28413496785903af39a0073e3ffbd3a57L182-R188): Modified the `_get_dataframe_list` method to fill missing columns with null values instead of excluding dataframes with missing columns.
* [`pyprobe/cyclers/basecycler.py`](diffhunk://#diff-fb018c144804be12e36facbe6465c3e28413496785903af39a0073e3ffbd3a57L204-R201): Updated the `get_imported_dataframe` method to use the "diagonal" concatenation method instead of "vertical".

### Changes to tests:

* [`tests/cyclers/test_basecycler.py`](diffhunk://#diff-8f8cc634eb406e9b5c4e2c167f589440834d4714a58d17758b3b1702c977b9abR6): Added import for `numpy` to support new test cases.
* [`tests/cyclers/test_basecycler.py`](diffhunk://#diff-8f8cc634eb406e9b5c4e2c167f589440834d4714a58d17758b3b1702c977b9abR359-R387): Added a new test case `test_with_missing_columns` to ensure dataframes with missing columns are handled correctly by filling missing values with nulls.