### PR TITLE
Fix time column reading for Neware and Biologic cyclers

### DIFF
--- a/tests/cyclers/test_biologic.py
+++ b/tests/cyclers/test_biologic.py
@@ -1,6 +1,7 @@
 """Tests for the neware module."""
 from datetime import datetime
 
+import numpy as np
 import polars as pl
 import polars.testing as pl_testing
 import pytest
@@ -42,6 +43,25 @@ def test_read_file(biologic_cycler, biologic_MB_cycler):
     assert (
         str(unprocessed_dataframe.select(pl.col("Date")).collect().item(0, 0))
         == start_time
+    )
+
+
+def test_read_file_timestamp():
+    """Test the read_file method."""
+    unprocessed_dataframe = Biologic(
+        input_data_path="tests/sample_data/biologic/"
+        "Sample_data_biologic_timestamped.txt"
+    )._imported_dataframe
+    assert isinstance(unprocessed_dataframe, pl.LazyFrame)
+    time_s = (
+        unprocessed_dataframe.select(pl.col("time/s"))
+        .cast(pl.Float64)
+        .collect()
+        .to_numpy()
+    )
+    np.testing.assert_allclose(
+        time_s.flatten(),
+        np.array([0, 6.464, 7.464, 8.464, 9.464, 10.464, 11.464, 12.464]),
     )
 
 

--- a/tests/cyclers/test_neware.py
+++ b/tests/cyclers/test_neware.py
@@ -23,16 +23,14 @@ def test_read_file(neware_cycler):
         "tests/sample_data/neware/sample_data_neware.xlsx"
     )
     assert isinstance(unprocessed_dataframe, pl.DataFrame)
-
     # Test that Time and Total time are read correctly
     expected_start = pl.DataFrame(
         {
-            "Time": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
             "Total Time": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
         }
     )
     pl_testing.assert_frame_equal(
-        neware_cycler._imported_dataframe.select("Time", "Total Time").head(6),
+        neware_cycler._imported_dataframe.select("Total Time").head(6),
         expected_start,
     )
     assert neware_cycler._imported_dataframe["Total Time"][-1] == 562784.5
@@ -229,3 +227,38 @@ def test_read_and_process_neware_multi_file(benchmark):
     helper_read_and_process(
         benchmark, neware_cycler, last_row, expected_events, expected_columns
     )
+
+
+def test_convert_neware_time_format():
+    """Test the _convert_neware_time_format method."""
+    data = pl.DataFrame(
+        {
+            "Total Time": [
+                "2022-02-02 02:02:00",
+                "2022-02-02 02:02:01",
+                "2022-02-02 02:02:02",
+                "2022-02-02 02:02:03",
+                "2022-02-02 02:02:04",
+                "2022-02-02 02:02:05",
+            ]
+        }
+    )
+    converted_data = Neware._convert_neware_time_format(data, "Total Time")
+    expected_data = pl.DataFrame({"Total Time": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]})
+    pl_testing.assert_frame_equal(converted_data, expected_data)
+
+    data = pl.DataFrame(
+        {
+            "Total Time": [
+                "00:00:00",
+                "00:00:01",
+                "00:00:02",
+                "00:00:03",
+                "00:00:04",
+                "00:00:05",
+            ]
+        }
+    )
+    converted_data = Neware._convert_neware_time_format(data, "Total Time")
+    expected_data = pl.DataFrame({"Total Time": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]})
+    pl_testing.assert_frame_equal(converted_data, expected_data)

--- a/tests/sample_data/biologic/Sample_data_biologic_timestamped.txt
+++ b/tests/sample_data/biologic/Sample_data_biologic_timestamped.txt
@@ -1,0 +1,106 @@
+BT-Lab ASCII FILE
+Nb header lines : 98                          
+
+Modulo Bat
+
+Run on channel : A1 (SN 0335)
+User : 
+Ecell ctrl range : min = 0.00 V, max = 9.00 V
+Safety Limits :
+	Ecell min = 2.45 V
+	Ecell max = 4.25 V
+	|I| = 9000.000 mA
+	for t > 10 ms
+	Temperature max = 70.00 �C
+Acquisition started on : 11/20/2024 11:38:41.707
+Technique started on : 11/20/2024 11:38:41.707
+Loaded Setting File :  NONE
+Saved on :
+	File : DMT-CAT-DriveCycle-20degC_01_MB_CA1.mpr
+	Directory : D:\Tom\DMT - CAT\
+	Host : 169.254.10.153
+Device : BCS-815 (SN 0433)
+Address : 169.254.146.81
+BT-LAB for windows v1.80 (software)
+Internet server v1.80 (firmware)
+Command interpretor v1.80 (firmware)
+Electrode material : 
+Initial state : 
+Electrolyte : 
+Comments : 
+Mass of active material : 0.001 mg
+ at x = 0.000
+Molecular weight of active material (at x = 0) : 0.001 g/mol
+Atomic weight of intercalated ion : 0.001 g/mol
+Acquisition started at : xo = 0.000
+Number of e- transfered per intercalated ion : 1
+for DX = 1, DQ = 26.802 mA.h
+Battery capacity : 4.500 A.h
+Electrode surface area : 0.000 cm�
+Characteristic mass : 0.001 g
+Volume (V) : 0.001 cm�
+Record Temperature
+Record energy
+Cycle Definition : Charge/Discharge alternance
+Ns                  0                   1                   2                   3                   
+ctrl_type           Rest                CC                  CV                  Rest                
+Apply I/C           I                   C x N               C x N               C x N               
+current/potential   current             current             current             current             
+ctrl1_val                               100.000             4.200                                   
+ctrl1_val_unit                          mA                  V                                       
+ctrl1_val_vs                            <None>              Ref                                     
+ctrl2_val                                                                                           
+ctrl2_val_unit                                                                                      
+ctrl2_val_vs                                                                                        
+ctrl3_val                                                                                           
+ctrl3_val_unit                                                                                      
+ctrl3_val_vs                                                                                        
+N                   1.00                0.10                0.10                0.10                
+charge/discharge    Charge              Charge              Charge              Charge              
+charge/discharge_1  Charge              Charge              Charge              Charge              
+Apply I/C_1         I                   I                   I                   I                   
+N1                  0.00                1.00                1.00                1.00                
+ctrl4_val                                                                                           
+ctrl4_val_unit                                                                                      
+ctrl5_val                                                                                           
+ctrl5_val_unit                                                                                      
+ctrl_tM             0                   0                   0                   0                   
+ctrl_seq            0                   0                   0                   0                   
+ctrl_repeat         0                   0                   0                   0                   
+ctrl_trigger        Falling Edge        Falling Edge        Falling Edge        Falling Edge        
+ctrl_TO_t           0.000               0.000               0.000               0.000               
+ctrl_TO_t_unit      d                   d                   d                   d                   
+ctrl_Nd             6                   6                   6                   6                   
+ctrl_Na             1                   1                   1                   1                   
+ctrl_corr           1                   1                   1                   1                   
+lim_nb              1                   1                   1                   1                   
+lim1_type           Time                Ecell               |I|                 Time                
+lim1_comp           >                   >                   <                   >                   
+lim1_Qprev_pct      100                 100                 100                 100                 
+lim1_Q              Q limit             Q limit             I limit             Q limit             
+lim1_value          120.000             4.200               90.000              24.000              
+lim1_value_unit     s                   V                   mA                  h                   
+lim1_action         Next sequence       Next sequence       Next sequence       Next sequence       
+lim1_seq            1                   2                   3                   4                   
+rec_nb              1                   1                   1                   1                   
+rec1_type           Time                Time                Time                Time                
+rec1_value          10.000              1.000               1.000               1.000               
+rec1_value_unit     s                   s                   s                   s                   
+E range min (V)     0.000               0.000               0.000               0.000               
+E range max (V)     9.000               9.000               9.000               9.000               
+I Range             10 mA               1 A                 1 A                 1 A                 
+I Range min         Unset               Unset               Unset               Unset               
+I Range max         Unset               Unset               Unset               Unset               
+I Range init        Unset               Unset               Unset               Unset               
+auto rest           0                   0                   0                   0                   
+Bandwidth           4                   4                   4                   4                   
+
+Ns changes	Ns	time/s	Ecell/V	I/mA	(Q-Qo)/mA.h	Energy charge/W.h	Energy discharge/W.h	step time/s	Q discharge/mA.h	Q charge/mA.h	Capacity/mA.h	cycle number	P/W	R/Ohm	Temperature/�C	
+0	0	11/20/2024 11:38:41.707	4.1465597E+000	0.0000000E+000	0.000000000000000E+000	0.000000000000000E+000	0.000000000000000E+000	0.000000000000000E+000	0.000000000000000E+000	0.000000000000000E+000	0.000000000000000E+000	0.000000000000000E+000	0.0000000E+000	0.0000000E+000	1.9379732E+001
+1	1	11/20/2024 11:38:48.171	4.1518364E+000	4.4993811E+002	2.499656168619792E-004	1.037816297743056E-006	0.000000000000000E+000	6.464000307023525E+000	0.000000000000000E+000	2.499656168619792E-004	2.499656168619792E-004	0.000000000000000E+000	1.8680694E+000	9.2275724E+000	1.9324554E+001
+0	1	11/20/2024 11:38:49.171	4.1529784E+000	4.4991840E+002	1.252344137064616E-001	5.200473001437718E-004	0.000000000000000E+000	7.464000354520977E+000	0.000000000000000E+000	1.252344137064616E-001	1.252344137064616E-001	0.000000000000000E+000	1.8685014E+000	9.2305145E+000	1.9490086E+001
+0	1	11/20/2024 11:38:50.171	4.1533723E+000	4.4993811E+002	2.502194307454427E-001	1.039132079128689E-003	0.000000000000000E+000	8.464000402018428E+000	0.000000000000000E+000	2.502194307454427E-001	2.502194307454427E-001	0.000000000000000E+000	1.8687605E+000	9.2309856E+000	1.9340321E+001
+0	1	11/20/2024 11:38:51.171	4.1538448E+000	4.4995779E+002	3.752053123474121E-001	1.558272465142144E-003	0.000000000000000E+000	9.464000449515879E+000	0.000000000000000E+000	3.752053123474121E-001	3.752053123474121E-001	0.000000000000000E+000	1.8690549E+000	9.2316322E+000	1.9348202E+001
+0	1	11/20/2024 11:38:52.171	4.1541204E+000	4.4989871E+002	5.001919928487142E-001	2.077458527357314E-003	0.000000000000000E+000	1.046400049701333E+001	0.000000000000000E+000	5.001919928487142E-001	5.001919928487142E-001	0.000000000000000E+000	1.8689334E+000	9.2334566E+000	1.9521616E+001
+0	1	11/20/2024 11:38:53.171	4.1544747E+000	4.5001691E+002	6.251781919352214E-001	2.596678972778320E-003	0.000000000000000E+000	1.146400054451078E+001	0.000000000000000E+000	6.251781919352213E-001	6.251781919352213E-001	0.000000000000000E+000	1.8695838E+000	9.2318192E+000	1.9300909E+001
+0	1	11/20/2024 11:38:54.171	4.1545930E+000	4.4991840E+002	7.501638655090332E-001	3.115929252590603E-003	0.000000000000000E+000	1.246400059200823E+001	0.000000000000000E+000	7.501638655090331E-001	7.501638655090331E-001	0.000000000000000E+000	1.8692278E+000	9.2341032E+000	1.9458557E+001


### PR DESCRIPTION
### Updates to `biologic` cycler:
* [`pyprobe/cyclers/biologic.py`](diffhunk://#diff-32774aee24ca8e95553b774cc303cbdabaefcdf26d368345377a1c7b355fd625R45-R65): Enhanced `read_file` method to handle timestamped data and convert timestamps to cumulative seconds if a specific datetime format is detected. [[1]](diffhunk://#diff-32774aee24ca8e95553b774cc303cbdabaefcdf26d368345377a1c7b355fd625R45-R65) [[2]](diffhunk://#diff-32774aee24ca8e95553b774cc303cbdabaefcdf26d368345377a1c7b355fd625L53-R79)

### Updates to `neware` cycler:
* [`pyprobe/cyclers/neware.py`](diffhunk://#diff-f98a123de8d0f3073501d715c5eafce742e688b1518a0715178cfc696e4fa5a6R26-R67): Added `_convert_neware_time_format` method to handle different Neware time formats and convert them to seconds. This method is now used in the `read_file` method to simplify time conversion logic. [[1]](diffhunk://#diff-f98a123de8d0f3073501d715c5eafce742e688b1518a0715178cfc696e4fa5a6R26-R67) [[2]](diffhunk://#diff-f98a123de8d0f3073501d715c5eafce742e688b1518a0715178cfc696e4fa5a6L37-R80)

### Testing enhancements:
* [`tests/cyclers/test_biologic.py`](diffhunk://#diff-3d9e9468a6c23d8b47f4c90934420a9b7f17846eb7702bd31c14bdc199917532R49-R67): Added a new test case `test_read_file_timestamp` to verify the correct processing of timestamped data in the `biologic` cycler.
* [`tests/cyclers/test_neware.py`](diffhunk://#diff-3c457bca57369bfffbf89267b7a0db777f928e273be033fe1fe5c918c2558c9eR230-R264): Added a new test case `test_convert_neware_time_format` to ensure the new `_convert_neware_time_format` method works as expected.

### Miscellaneous:
* [`pyprobe/cyclers/biologic.py`](diffhunk://#diff-32774aee24ca8e95553b774cc303cbdabaefcdf26d368345377a1c7b355fd625R4): Imported the `re` module to support regular expression matching for datetime format detection.
* [`tests/sample_data/biologic/Sample_data_biologic_timestamped.txt`](diffhunk://#diff-e076d305324c981bec9157d96ddb19d0a704da534845966bfbe0cd0a519b0ed1R1-R106): Added a sample data file for testing timestamped data processing in the `biologic` cycler.