### PR TITLE
Fix search for experiment capacity on pulsing module methods

### DIFF
--- a/pyprobe/analysis/pulsing.py
+++ b/pyprobe/analysis/pulsing.py
@@ -193,7 +193,7 @@ def get_resistances(
         pulse_df = pulse_df.select(
             [
                 "Pulse Number",
-                "Experiment Capacity [Ah]",
+                "Capacity [Ah]",
                 "SOC",
                 "OCV [V]",
                 "R0 [Ohms]",
@@ -204,7 +204,7 @@ def get_resistances(
         pulse_df = pulse_df.select(
             [
                 "Pulse Number",
-                "Experiment Capacity [Ah]",
+                "Capacity [Ah]",
                 "SOC",
                 "OCV [V]",
                 "R0 [Ohms]",
@@ -213,9 +213,7 @@ def get_resistances(
 
     column_definitions = {
         "Pulse Number": "An index for each pulse.",
-        "Experiment Capacity [Ah]": input_data.column_definitions[
-            "Experiment Capacity [Ah]"
-        ],
+        "Capacity [Ah]": input_data.column_definitions["Capacity [Ah]"],
         "SOC": input_data.column_definitions["SOC"],
         "OCV [V]": "The voltage value at the final data point in the rest before a "
         "pulse.",


### PR DESCRIPTION
This pull request fixes a bug in `pulsing.py` where previous type requirements were expecting `"Experiment Capacity [Ah]"` to be available as a column, which may not be the case with the looser type requirements of the new method.

Column name standardization:

* Updated the column name from `"Experiment Capacity [Ah]"` to `"Capacity [Ah]"` in multiple places within the `get_resistances` function. [[1]](diffhunk://#diff-093ee3a38fdadafed5fe53a40e7e01df61e4a14f530abb558de9200c83f67781L196-R196) [[2]](diffhunk://#diff-093ee3a38fdadafed5fe53a40e7e01df61e4a14f530abb558de9200c83f67781L207-R207) [[3]](diffhunk://#diff-093ee3a38fdadafed5fe53a40e7e01df61e4a14f530abb558de9200c83f67781L216-R216)