### PR TITLE
Add user warning when running show_image() on Windows

### DIFF
--- a/pyprobe/plot.py
+++ b/pyprobe/plot.py
@@ -1,4 +1,6 @@
 """A module to contain plotting functions for PyProBE."""
+import platform
+import warnings
 from typing import TYPE_CHECKING, List, Optional
 
 import numpy as np
@@ -60,6 +62,11 @@ class Plot:
 
     def show_image(self) -> None:
         """Show the plot as an image."""
+        if platform.system() == "Windows":
+            warnings.warn(
+                "show_image() is known to hang indefinitely on Windows. "
+                "If you encounter this issue, use show() instead."
+            )
         img_bytes = self.fig.to_image(format="png")
         display(Image(img_bytes))
 


### PR DESCRIPTION
This pull request includes changes to the `pyprobe/plot.py` file to enhance compatibility and provide warnings for potential issues on specific platforms. The most important changes include importing necessary modules and adding a warning for Windows users about a known issue with the `show_image` method.

Platform compatibility and warnings:

* [`pyprobe/plot.py`](diffhunk://#diff-1bf1c7e92a3dffb62f089137efb973b16d6e598902e680fdece240899bd3f7c1R2-R3): Imported the `platform` and `warnings` modules to handle platform-specific behavior and issue warnings.
* [`pyprobe/plot.py`](diffhunk://#diff-1bf1c7e92a3dffb62f089137efb973b16d6e598902e680fdece240899bd3f7c1R65-R69): Added a warning in the `show_image` method to notify Windows users about the potential for the method to hang indefinitely, suggesting the use of `show()` as an alternative.

Closes #145 