### PR TITLE
docs: update readme and user manual to reflect plotting integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ PyProBE works with numerous cyclers. For guidance on how to export your data to 
 <details>
 <summary><strong style="font-size: 1.2em;">2. Accelerate battery data exploration</strong></summary>
 
-PyProBE has a built-in [plotting](https://imperialcollegelondon.github.io/PyProBE/api/pyprobe.plot.html) module for fast and flexible visualisation of battery data. It also includes a graphical user interface (GUI) 
+PyProBE has built-in plotting methods that integrate with [matplotlib](https://matplotlib.org/), [hvplot](https://hvplot.holoviz.org/) and [seaborn](https://seaborn.pydata.org/index.html) for fast and flexible visualization of battery data. It also includes a graphical user interface (GUI) 
 for exploring data interactively, with almost no code. Run the 
 [getting started](./docs/source/examples/getting-started.ipynb) example locally to try the GUI.
 

--- a/docs/source/user_guide/plotting.rst
+++ b/docs/source/user_guide/plotting.rst
@@ -3,28 +3,53 @@
 Plotting
 ========
 
-PyProBE has a plotting module that can display any :class:`~pyprobe.rawdata.RawData`
-or :class:`~pyprobe.result.Result` object. The plotting module is based on
-`plotly <https://plot.ly/python/>`_. 
+PyProBE includes plotting methods that integrate directly with popular Python visualisation
+tools. Using a backend powered by `Pandas <https://pandas.pydata.org/>`_ and `matplotlib <https://matplotlib.org/>`_, you can call the 
+:func:`~pyprobe.result.Result.plot` method on any :class:`~pyprobe.result.Result` object.
 
-You first create a plot instance:
+For more interactive plotting, you can use install the optional dependency `hvPlot <https://hvplot.holoviz.org/>`_:
+
+.. code-block:: bash
+
+    pip install 'PyProBE-Data[hvplot]'
+
+This enables the :func:`~pyprobe.result.Result.hvplot` method which creates interactive plots for
+visual inspection.
+
+The :func:`~pyprobe.result.Result.plot` and :func:`~pyprobe.result.Result.hvplot` 
+interfaces are very similar. For example, creation of a simple plot might look like:
 
 .. code-block:: python
 
-    plot = pyprobe.Plot()
+    result = cell.procedure['Procedure Name'].experiment('Experiment Name').cycle(1)
+    
+    # for matplotlib
+    result.plot(x='Time [s]', y='Voltage [V]')
 
-Then you can add data to and display the plot:
+    # for hvplot
+    result.hvplot(x='Time [s]', y='Voltage [V]')
+
+
+PyProBE also includes a wrapper for the `Seaborn <https://seaborn.pydata.org/index.html>`_ 
+package. This allows you to pass any :class:`~pyprobe.result.Result` object to the `data`
+argument of any seaborn method:
 
 .. code-block:: python
 
-    result = cell.procedure['Procedure Name'].experiment('Experiment Name').cycle(4).charge(2)
-    plot.add_line(result, 'Time [s]', 'Voltage [V]')
-    plot.show()
+    from pyprobe.plot import seaborn as sns
 
-:func:`~pyprobe.plot.Plot.add_line` adds a line to the plot. The first argument is the 
-:class:`~pyprobe.rawdata.RawData` or :class:`~pyprobe.result.Result` object data to be 
-plotted, the second and third arguments are quantities to plot in x and y.
+    sns.scatterplot(result, x='Time [s]', y='Voltage [V]')
 
-For other plot types see the :class:`~pyprobe.plot.Plot` class documentation.
+
+Seaborn must be installed as an optional dependency:
+
+.. code-block:: bash
+
+    pip install 'PyProBE-Data[seaborn]'
+
+All of these methods are light wrappers, meaning you can refer to the original package 
+documentation for details on methods to customise your plots further. To get started with
+plotting view the :doc:`example <../examples/plotting>`.
+
 
 .. footbibliography::


### PR DESCRIPTION
This pull request includes updates to the documentation to reflect changes in the plotting capabilities of PyProBE. The most important changes include updating the README and user guide to describe the new integrations with popular Python visualization tools.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R54): Updated the description of the plotting capabilities to mention integration with `matplotlib`, `hvplot`, and `seaborn` instead of a built-in plotting module.
* [`docs/source/user_guide/plotting.rst`](diffhunk://#diff-4a1e09b951e042b62a4f8d20f32adf759fbe941932047b96053b7942d76cc510L6-L28): Revised the user guide to explain how to use the new plotting methods with `matplotlib`, `hvplot`, and `seaborn`, including installation instructions for optional dependencies and example code snippets.