### PR TITLE
chore: update workflow to v7 of create-pull-request gh action [skip ci]

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -44,7 +44,7 @@ jobs:
         run: uv lock --upgrade-package pyprobe-data
 
       - name: Open Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v7
         with:
           branch: release-candidates/rc-${{ steps.bump.outputs.version }}
           title: "Release Candidate ${{ steps.bump.outputs.version }}"


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow for creating release candidates. The most important change is the upgrade of the action used to open pull requests.

* [`.github/workflows/create-release-candidate.yml`](diffhunk://#diff-a7d1ecec46c0cc4f70df2abd18a437b1ffa9eb50b8e06547ea60cf4402db609aL47-R47): Updated the `peter-evans/create-pull-request` action from version 4 to version 7.