### PR TITLE
Fix example output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Run tests
         run: uv run pytest tests --benchmark-json output.json --cov-report=xml
 
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage.xml
+
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,7 @@ jobs:
           uv sync --all-extras
 
       - name: Run tests
-        run: uv run pytest tests --benchmark-json output.json --cov-branch --cov-report=xml
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+        run: uv run pytest tests --benchmark-json output.json --cov-report=xml
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
@@ -55,4 +50,9 @@ jobs:
           # Enable Job Summary for PRs
           summary-always: true
       - name: Test notebooks
-        run: uv run pytest --nbmake docs/source/examples/*ipynb --ignore --nbmake docs/source/examples/comparing-pyprobe-performance.ipynb
+        run: uv run pytest --nbmake docs/source/examples/*ipynb --ignore docs/source/examples/comparing-pyprobe-performance.ipynb
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,4 @@ jobs:
           # Enable Job Summary for PRs
           summary-always: true
       - name: Test notebooks
-        run: uv run pytest --nbmake docs/source/examples/*ipynb
+        run: uv run pytest --nbmake docs/source/examples/*ipynb --ignore --nbmake docs/source/examples/comparing-pyprobe-performance.ipynb

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,25 @@
+name: "Upload coverage on PR merge"
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  coverage-upload:
+    # Only run if the pull request was actually merged, not just closed
+    if: ${{ github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+          path: "."
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          override_branch: main

--- a/docs/source/examples/LEAN-differentiation.ipynb
+++ b/docs/source/examples/LEAN-differentiation.ipynb
@@ -22,12 +22,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%capture\n",
     "%pip install matplotlib\n",
     "import pyprobe\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "info_dictionary = {\n",
     "    \"Name\": \"Sample cell\",\n",
     "    \"Chemistry\": \"NMC622\",\n",

--- a/docs/source/examples/analysing-GITT-data.ipynb
+++ b/docs/source/examples/analysing-GITT-data.ipynb
@@ -18,12 +18,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%capture\n",
     "%pip install matplotlib\n",
     "import pyprobe\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "info_dictionary = {\n",
     "    \"Name\": \"Sample cell\",\n",
     "    \"Chemistry\": \"NMC622\",\n",

--- a/docs/source/examples/comparing-pyprobe-performance.ipynb
+++ b/docs/source/examples/comparing-pyprobe-performance.ipynb
@@ -15,6 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%capture\n",
     "%pip install matplotlib\n",
     "%pip install pandas\n",
     "import pyprobe\n",

--- a/docs/source/examples/differentiating-voltage-data.ipynb
+++ b/docs/source/examples/differentiating-voltage-data.ipynb
@@ -24,12 +24,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%capture\n",
     "%pip install matplotlib\n",
     "import pyprobe\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "info_dictionary = {\n",
     "    \"Name\": \"Sample cell\",\n",
     "    \"Chemistry\": \"NMC622\",\n",

--- a/docs/source/examples/filtering-data.ipynb
+++ b/docs/source/examples/filtering-data.ipynb
@@ -21,12 +21,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%capture\n",
     "%pip install matplotlib\n",
     "import pyprobe\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "info_dictionary = {\n",
     "    \"Name\": \"Sample cell\",\n",
     "    \"Chemistry\": \"NMC622\",\n",

--- a/docs/source/examples/getting-started.ipynb
+++ b/docs/source/examples/getting-started.ipynb
@@ -13,6 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%capture\n",
     "%pip install matplotlib\n",
     "import pyprobe\n",
     "from pprint import pprint\n",

--- a/docs/source/examples/ocv-fitting.ipynb
+++ b/docs/source/examples/ocv-fitting.ipynb
@@ -15,6 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%capture\n",
     "%pip install matplotlib\n",
     "import pyprobe\n",
     "import polars as pl\n",

--- a/docs/source/examples/plotting.ipynb
+++ b/docs/source/examples/plotting.ipynb
@@ -21,11 +21,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%capture\n",
     "%pip install matplotlib\n",
     "import pyprobe\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "%matplotlib inline\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "info_dictionary = {\n",
     "    \"Name\": \"Sample cell\",\n",
     "    \"Chemistry\": \"NMC622\",\n",

--- a/docs/source/examples/working-with-pybamm-models.ipynb
+++ b/docs/source/examples/working-with-pybamm-models.ipynb
@@ -24,6 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%capture\n",
     "%pip install pybamm\n",
     "%pip install matplotlib\n",
     "%pip install ipywidgets\n",


### PR DESCRIPTION
This pull request includes changes to the testing configuration and several Jupyter notebooks in the documentation. The most important changes involve updating the testing command in the CI workflow and adding a new Jupyter magic command to suppress output in the notebooks.

Updates to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL53-R53): Modified the test command to ignore a specific notebook during testing. (`--ignore --nbmake docs/source/examples/comparing-pyprobe-performance.ipynb`)

Improvements to Jupyter notebooks:

* [`docs/source/examples/LEAN-differentiation.ipynb`](diffhunk://#diff-3c370a8e71bfa5b4f9230a585200edede1e728f18c854862b44cd8e7743d19a3R25-R38): Added `%%capture` to suppress output and adjusted the `%matplotlib inline` command.
* [`docs/source/examples/analysing-GITT-data.ipynb`](diffhunk://#diff-53553d4815ffbf58355dcb78b757c524044a92162ffd9e50183500c67825abadR21-R34): Added `%%capture` to suppress output and adjusted the `%matplotlib inline` command.
* [`docs/source/examples/comparing-pyprobe-performance.ipynb`](diffhunk://#diff-f97df501eeb86d9944940d597c2c80a87b666e5ecd0715eb1cd37238964dc9e1R18): Added `%%capture` to suppress output.
* [`docs/source/examples/differentiating-voltage-data.ipynb`](diffhunk://#diff-dcf998def972b31c70673da2b876e75d0c56a5f5a182bd98fee9637c7e3ec45eR27-R40): Added `%%capture` to suppress output and adjusted the `%matplotlib inline` command.