### PR TITLE
docs: add matplotlib inline to pybamm example

### DIFF
--- a/docs/source/examples/working-with-pybamm-models.ipynb
+++ b/docs/source/examples/working-with-pybamm-models.ipynb
@@ -30,7 +30,9 @@
     "%pip install ipywidgets\n",
     "import pyprobe\n",
     "import pybamm\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "%matplotlib inline"
    ]
   },
   {


### PR DESCRIPTION
This pull request includes a small change to the `docs/source/examples/working-with-pybamm-models.ipynb` file. The change adds a line to enable inline plotting with Matplotlib.

Changes in file `docs/source/examples/working-with-pybamm-models.ipynb`:

* Added `%matplotlib inline` to enable inline plotting with Matplotlib.