### PR TITLE
Fix parquet read speed example

### DIFF
--- a/docs/source/examples/analysing-GITT-data.ipynb
+++ b/docs/source/examples/analysing-GITT-data.ipynb
@@ -19,7 +19,15 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install matplotlib\n",
+    "%pip install matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import pyprobe\n",
     "import matplotlib.pyplot as plt\n",
     "\n",

--- a/docs/source/examples/comparing-pyprobe-performance.ipynb
+++ b/docs/source/examples/comparing-pyprobe-performance.ipynb
@@ -17,7 +17,15 @@
    "source": [
     "%%capture\n",
     "%pip install matplotlib\n",
-    "%pip install pandas\n",
+    "%pip install pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import pyprobe\n",
     "import pandas as pd\n",
     "import polars as pl\n",
@@ -480,8 +488,10 @@
     "        overwrite_existing=True,\n",
     "        compression_priority=priority,\n",
     "    )\n",
-    "    file_sizes[i] = os.path.getsize(data_directory + f\"/sample_data_neware.parquet\")\n",
-    "    pyprobe_time, _, _ = measure_pyprobe(repeats, \"sample_data_neware.parquet\")\n",
+    "    file_sizes[i] = os.path.getsize(\n",
+    "        data_directory + f\"/sample_data_neware_test.parquet\"\n",
+    "    )\n",
+    "    pyprobe_time, _, _ = measure_pyprobe(repeats, \"sample_data_neware_test.parquet\")\n",
     "    times[i, :] = pyprobe_time[-1, :]\n",
     "\n",
     "file_sizes = np.append(\n",

--- a/docs/source/examples/differentiating-voltage-data.ipynb
+++ b/docs/source/examples/differentiating-voltage-data.ipynb
@@ -25,7 +25,15 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install matplotlib\n",
+    "%pip install matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import pyprobe\n",
     "import matplotlib.pyplot as plt\n",
     "\n",

--- a/docs/source/examples/filtering-data.ipynb
+++ b/docs/source/examples/filtering-data.ipynb
@@ -22,7 +22,15 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install matplotlib\n",
+    "%pip install matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import pyprobe\n",
     "import matplotlib.pyplot as plt\n",
     "\n",

--- a/docs/source/examples/getting-started.ipynb
+++ b/docs/source/examples/getting-started.ipynb
@@ -14,7 +14,15 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install matplotlib\n",
+    "%pip install matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import pyprobe\n",
     "from pprint import pprint\n",
     "\n",

--- a/docs/source/examples/ocv-fitting.ipynb
+++ b/docs/source/examples/ocv-fitting.ipynb
@@ -16,7 +16,15 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install matplotlib\n",
+    "%pip install matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import pyprobe\n",
     "import polars as pl\n",
     "from pyprobe.analysis import degradation_mode_analysis as dma\n",

--- a/docs/source/examples/plotting.ipynb
+++ b/docs/source/examples/plotting.ipynb
@@ -22,7 +22,15 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install matplotlib\n",
+    "%pip install matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import pyprobe\n",
     "import matplotlib.pyplot as plt\n",
     "\n",

--- a/docs/source/examples/sharing-data.ipynb
+++ b/docs/source/examples/sharing-data.ipynb
@@ -17,6 +17,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%capture\n",
+    "%pip install matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import pyprobe\n",
     "import os\n",
     "import shutil\n",

--- a/docs/source/examples/working-with-pybamm-models.ipynb
+++ b/docs/source/examples/working-with-pybamm-models.ipynb
@@ -27,7 +27,15 @@
     "%%capture\n",
     "%pip install pybamm\n",
     "%pip install matplotlib\n",
-    "%pip install ipywidgets\n",
+    "%pip install ipywidgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import pyprobe\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",


### PR DESCRIPTION
This pull request includes changes to multiple Jupyter notebooks in the `docs/source/examples` directory. The main goal of these changes is to improve the structure and readability of the notebooks by separating the installation of dependencies into their own code cells.

Improvements to notebook structure:

* [`docs/source/examples/analysing-GITT-data.ipynb`](diffhunk://#diff-53553d4815ffbf58355dcb78b757c524044a92162ffd9e50183500c67825abadL22-R30): Moved the `%pip install matplotlib` command to its own code cell.
* [`docs/source/examples/comparing-pyprobe-performance.ipynb`](diffhunk://#diff-f97df501eeb86d9944940d597c2c80a87b666e5ecd0715eb1cd37238964dc9e1L20-R28): Moved the `%pip install matplotlib` and `%pip install pandas` commands to their own code cells.
* [`docs/source/examples/differentiating-voltage-data.ipynb`](diffhunk://#diff-dcf998def972b31c70673da2b876e75d0c56a5f5a182bd98fee9637c7e3ec45eL28-R36): Moved the `%pip install matplotlib` command to its own code cell.
* [`docs/source/examples/filtering-data.ipynb`](diffhunk://#diff-51237e5efd3ebcc59d5ae2789421e31be6b3197ecb458ee2d4c71b817f0627b1L25-R33): Moved the `%pip install matplotlib` command to its own code cell.
* [`docs/source/examples/getting-started.ipynb`](diffhunk://#diff-9ebd7baa6c2b3e38546f9ea57dbabc7272156497ee944769768284b8f3391f06L17-R25): Moved the `%pip install matplotlib` command to its own code cell.
* [`docs/source/examples/ocv-fitting.ipynb`](diffhunk://#diff-af063695ab1366d8cf99d16a877bf32ec5492ac795a982b86b1579df137b3da6L19-R27): Moved the `%pip install matplotlib` command to its own code cell.
* [`docs/source/examples/plotting.ipynb`](diffhunk://#diff-ef234c01fc4ec05352d294f88a5f0dec6945ece006bb115a42207ee4ebf2af37L25-R33): Moved the `%pip install matplotlib` command to its own code cell.
* [`docs/source/examples/sharing-data.ipynb`](diffhunk://#diff-f7fe37d3ca5db488bd5f859724fb5d3047e37f433cb56a2ef755553262d86bc8R14-R23): Added a new code cell for the `%pip install matplotlib` command.
* [`docs/source/examples/working-with-pybamm-models.ipynb`](diffhunk://#diff-4dbafabc9f2fd6fbddd2462ef20e54a871fd842d276e2a7baef4b42fb1b2cfd5L30-R38): Moved the `%pip install ipywidgets` command to its own code cell.

Additionally, there was a minor change to the file name used in the `measure_pyprobe` function call in the `comparing-pyprobe-performance.ipynb` notebook:

* [`docs/source/examples/comparing-pyprobe-performance.ipynb`](diffhunk://#diff-f97df501eeb86d9944940d597c2c80a87b666e5ecd0715eb1cd37238964dc9e1L483-R494): Changed the file name in the `measure_pyprobe` function call from `sample_data_neware.parquet` to `sample_data_neware_test.parquet`.