### PR TITLE
Fix biologic mb import errors

### DIFF
--- a/pyprobe/cyclers/basecycler.py
+++ b/pyprobe/cyclers/basecycler.py
@@ -210,7 +210,7 @@ class BaseCycler(BaseModel):
         all_columns = set([col for df in list for col in df.collect_schema().names()])
         for i in range(len(list)):
             if len(list[i].collect_schema().names()) < len(all_columns):
-                warnings.warn(
+                logger.warning(
                     f"File {os.path.basename(files[i])} has missing columns, "
                     "these have been filled with null values."
                 )

--- a/pyprobe/cyclers/biologic.py
+++ b/pyprobe/cyclers/biologic.py
@@ -114,7 +114,7 @@ class BiologicMB(Biologic):
         for i, df in enumerate(dataframe_list):
             df = df.with_columns(pl.lit(i).alias("MB File"))
             df_list.append(df)
-        complete_df = pl.concat(df_list, how="vertical")
+        complete_df = pl.concat(df_list, how="diagonal")
         complete_df = self.apply_step_correction(complete_df)
         return complete_df
 


### PR DESCRIPTION
This pull request includes include replacing a warning with a logger warning and modifying the method of concatenating dataframes for biologic_MB files.

Logging improvements:

* [`pyprobe/cyclers/basecycler.py`](diffhunk://#diff-fb018c144804be12e36facbe6465c3e28413496785903af39a0073e3ffbd3a57L213-R213): Replaced `warnings.warn` with `logger.warning` to improve logging practices in the `_get_dataframe_list` method.

Data concatenation method:

* [`pyprobe/cyclers/biologic.py`](diffhunk://#diff-32774aee24ca8e95553b774cc303cbdabaefcdf26d368345377a1c7b355fd625L117-R117): Changed the `how` parameter from "vertical" to "diagonal" in the `pl.concat` function to modify the method of concatenating dataframes in the `get_imported_dataframe` method.