### PR TITLE
feat: add capability to export any Result object to a .mat file

### DIFF
--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -6,6 +6,8 @@ import numpy.testing as np_testing
 import polars as pl
 import polars.testing as pl_testing
 import pytest
+from scipy.io import loadmat
+import os
 
 from pyprobe.result import PolarsColumnCache, Result, combine_results
 
@@ -480,3 +482,25 @@ def test_combine_results():
     pl_testing.assert_frame_equal(
         combined_result.data, expected_data, check_column_order=False
     )
+
+
+def test_export_to_mat(Result_fixture):
+    """Test the export to mat function."""
+    Result_fixture.export_to_mat("./test_mat.mat")
+    saved_data = loadmat("./test_mat.mat")
+    assert "data" in saved_data.keys()
+    assert "info" in saved_data.keys()
+    expected_columns = set(
+        [
+            "Current__A_",
+            "Step",
+            "Event",
+            "Time__s_",
+            "Capacity__Ah_",
+            "Voltage__V_",
+            "Date",
+        ]
+    )
+    actual_columns = set(saved_data["data"].dtype.names)
+    assert actual_columns == expected_columns
+    os.remove("./test_mat.mat")


### PR DESCRIPTION
This pull request introduces a new feature to export data to a `.mat` file and includes the necessary tests for this functionality. The most important changes include importing required libraries, adding the `export_to_mat` method, and creating a test to verify the new method. Closes #216.

### New feature: Export data to `.mat` file

* [`pyprobe/result.py`](diffhunk://#diff-f6271fc55361775ee0d28df48b7f18a4ac1dfc4ba9e2e3005a512f807baca9b5R14-R15): Imported `savemat` from `scipy.io` and `re` module to support the new export functionality.
* [`pyprobe/result.py`](diffhunk://#diff-f6271fc55361775ee0d28df48b7f18a4ac1dfc4ba9e2e3005a512f807baca9b5R605-R631): Added `export_to_mat` method to the `Result` class to export data and info dictionary to a `.mat` file, ensuring MATLAB variable naming compliance by replacing non-alphanumeric characters with underscores.

### Testing the new feature

* [`tests/test_result.py`](diffhunk://#diff-2c0771724e9886ac20d94971066455855a26b2bbf4f5d5dc094e36a5a50cd19eR9-R10): Imported `loadmat` from `scipy.io` and `os` module to support the testing of the new export functionality.
* [`tests/test_result.py`](diffhunk://#diff-2c0771724e9886ac20d94971066455855a26b2bbf4f5d5dc094e36a5a50cd19eR485-R506): Added `test_export_to_mat` function to verify that the `export_to_mat` method correctly exports data and info to a `.mat` file and cleans up the test file after the check.