### PR TITLE
fix(cyclers.biologic): add "Ewe/*" as a column alias for "Voltage [V]"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on:
     branches:
       - main
     paths:
-      - pyprobe/*
-      - tests/*
+      - pyprobe/**
+      - tests/**
       - docs/source/examples/*ipynb
       - pyproject.toml
       - .github/workflows/ci.yml
@@ -14,8 +14,8 @@ on:
     branches:
       - main
     paths:
-      - pyprobe/*
-      - tests/*
+      - pyprobe/**
+      - tests/**
       - pyproject.toml
       - .github/workflows/ci.yml
       - uv.lock

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -8,9 +8,9 @@ on:
     branches:
       - main
     paths:
-      - pyprobe/*
-      - tests/sample_data/*
-      - docs/*
+      - pyprobe/**
+      - tests/sample_data/**
+      - docs/**
       - pyproject.toml
       - .github/workflows/sphinx.yml
       - uv.lock

--- a/pyprobe/cyclers/biologic.py
+++ b/pyprobe/cyclers/biologic.py
@@ -23,6 +23,7 @@ class Biologic(BaseCycler):
         "Q charge/*": "Charge Capacity [*]",
         "Q discharge/*": "Discharge Capacity [*]",
         "Temperature/*": "Temperature [*]",
+        "Ewe/*": "Voltage [*]",
     }
 
     @staticmethod


### PR DESCRIPTION
This pull request includes a small change to the `pyprobe/cyclers/biologic.py` file. The change adds a new key-value pair to the dictionary within the `Biologic` class to include voltage measurements. Relevant for EC-lab generated biologic .mpt files.

* [`pyprobe/cyclers/biologic.py`](diffhunk://#diff-32774aee24ca8e95553b774cc303cbdabaefcdf26d368345377a1c7b355fd625R26): Added a new dictionary entry for `"Ewe/*"` to map to `"Voltage [*]"`.