### PR TITLE
Fix __version__ attribute from built package

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -50,3 +50,22 @@ jobs:
       
       - name: Test upgraded dependencies
         run: uv run --extra dev --upgrade --isolated pytest -n auto
+
+      - name: Build and create clean virtual environment
+        run: |
+          uv sync --all-extras --frozen
+          uv build
+          uv venv
+          echo "WHEEL_FILE=$(ls dist/*.whl | head -n 1)" >> $GITHUB_ENV
+
+      - name: Install wheel with all optional dependencies
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: uv pip install "${WHEEL_FILE}[hvplot,seaborn,dev,docs,pybamm]"
+
+      - name: Install wheel with all optional dependencies (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: uv pip install "$env:WHEEL_FILE[hvplot,seaborn,dev,docs,pybamm]"
+
+      - name: Run tests
+        run: uv run --no-sync pytest -n auto

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -47,7 +47,14 @@ jobs:
         run: |
             uv sync --all-extras --frozen
             uv build
+            echo "WHEEL_FILE=$(ls dist/*.whl | head -n 1)" >> $GITHUB_ENV
 
+      - name: Test build
+        run: |
+          uv venv
+          uv pip install "${WHEEL_FILE}[hvplot,seaborn,dev,docs,pybamm]"
+          uv run --no-sync pytest -n auto
+          
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-pypi-install.yml
+++ b/.github/workflows/test-pypi-install.yml
@@ -1,0 +1,28 @@
+name: "Test PyPI Install After Release"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test-pypi-install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.6.16"
+
+      - name: Wait for PyPI propagation
+        run: sleep 20
+
+      - name: Test install from PyPI
+        run: |
+          uv venv
+          uv pip install PyProBE-Data[hvplot,seaborn,dev,docs,pybamm]
+          uv run --no-sync pytest -n auto

--- a/pyprobe/_version.py
+++ b/pyprobe/_version.py
@@ -1,10 +1,18 @@
 """Version information."""
 
 import tomllib
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
-# Get version from pyproject.toml
+# Try to get version from pyproject.toml first (for development)
 pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
-with open(pyproject_path, "rb") as f:
-    pyproject_data = tomllib.load(f)
-__version__ = pyproject_data["project"]["version"]
+try:
+    with open(pyproject_path, "rb") as f:
+        pyproject_data = tomllib.load(f)
+    __version__ = pyproject_data["project"]["version"]
+except FileNotFoundError:
+    # Fallback to installed package metadata if pyproject.toml not available
+    try:
+        __version__ = version("PyProBE-Data")
+    except (ImportError, PackageNotFoundError):
+        __version__ = "unknown"


### PR DESCRIPTION
This pull request introduces several enhancements to the CI/CD workflows and improves version handling in the `PyProBE-Data` package. The most significant changes include adding new steps to build and test the package in CI workflows, creating a new workflow to test PyPI installations after releases, and improving the logic for retrieving the package version during development and production.

### CI/CD Workflow Enhancements:

* [`.github/workflows/ci-pull-request.yml`](diffhunk://#diff-acf67cd966818ebc84448ac232d72a839c228bb5be78abc04bf07e8db40c73a2R53-R71): Added steps to build the package, create a clean virtual environment, install the wheel with optional dependencies, and run tests across different operating systems.
* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R50-R56): Added a step to extract the wheel file name and included a new test build step to validate the package before uploading artifacts.

### New Workflow for PyPI Installation Testing:

* [`.github/workflows/test-pypi-install.yml`](diffhunk://#diff-e33884b29f7c86a9b0ca270259b792e0ddba3b39dff5764fc70e316257f68d71R1-R28): Created a new workflow triggered on release publication to test installing the package from PyPI and running tests in a virtual environment.

### Version Handling Improvements:

* [`pyprobe/_version.py`](diffhunk://#diff-8a5bf778259882720cf0adb15dbcccfe13247504ff855caaf78af0c2bce46591R4-R18): Enhanced version retrieval logic to first attempt reading from `pyproject.toml` during development and fall back to installed package metadata if the file is unavailable, ensuring robustness in both development and production environments.