### PR TITLE
chore: fix pypi installation test workflow

### DIFF
--- a/.github/workflows/test-pypi-install.yml
+++ b/.github/workflows/test-pypi-install.yml
@@ -11,8 +11,10 @@ permissions:
   contents: read
 jobs:
   test-pypi-install:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
This pull request makes a small update to the workflow file `.github/workflows/test-pypi-install.yml` to improve the reliability of the `test-pypi-install` job.

* The job now only runs if the triggering workflow completed successfully, ensuring tests are only executed after a successful workflow run.
* The workflow now checks out the repository using `actions/checkout@v4` before running the test steps, which is necessary for accessing the code during the job.