### PR TITLE
Add point preceding filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,7 +142,13 @@ tests/sample_data/test_data_2.csv
 tests/sample_data/test_data.csv
 
 # coding agents
-**/agents/
+*claude*
+*gemini*
+*agents*
+openspec
 
-# Git worktrees
-**/.worktrees/
+# Git/GitHub
+.worktrees
+.github
+# Include GitHub Actions workflows
+!.github/workflows

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ tests/sample_data/test_data.csv
 
 # coding agents
 **/agents/
+
+# Git worktrees
+**/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -145,4 +145,4 @@ tests/sample_data/test_data.csv
 **/agents/
 
 # Git worktrees
-**/worktrees/
+**/.worktrees/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: v0.15.6
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
         types_or: [ python, pyi, jupyter ]
         args: [ --fix ]
       # Run the formatter.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,62 +1,72 @@
 # Contributing to PyProBE
 
-Contributions to PyProBE are welcome. 
+Contributions are welcome. Open an issue first to discuss changes, then follow these steps.
 
-If you have a suggestion, please open an issue describing in detail the change you would like to be made. Similarly, if you have found a bug or a mistake, please open an issue describing this in detail.
+## Setup
 
-If you would like to contribute code, please:
-
-1. Install PyProBE with [developer settings](https://pyprobe.readthedocs.io/en/latest/developer_guide/developer_installation.html)
-
-2. Open an issue to detail the change/addition you wish to make, unless one already exists
-
-3. Create a feature branch and make your changes. PyProBE uses the [angular commit style](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits), please ensure your commits follow this syntax before pushing your changes
-
-4. Follow [Google's docstring style](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings) and ensure that the documentation builds successfully:
-
+1. Clone the repository and navigate to it.
+2. Install uv if not already installed: https://docs.astral.sh/uv/getting-started/installation/
+3. Install dependencies and pre-commit hooks:
 ```bash
-$ cd docs
-$ make html
+uv sync
+uv run pre-commit install
+```
+4. Verify setup by running tests:
+```bash
+uv run pytest
 ```
 
-5. Ensure that all tests pass (this is best done with uv if you have installed with this tool):
+## Code Standards
 
+- **DataFrame ops:** polars expressions only. Keep data as `LazyFrame`; convert to `DataFrame` only when needed. Numpy only for complex logic in `pyprobe/analysis/`.
+
+- **Docstrings:** Google style.
+
+- **Type hints:** required on all public function signatures. Use 3.10+ syntax:
+  - `X | None` not `Optional[X]`
+  - `list[int]` not `List[int]`
+  - `tuple[str, ...]` not `Tuple[str, ...]`
+
+- **Exceptions:** use specific types (`ValueError`, `TypeError`, `KeyError`, etc.). No bare `except:` or `except Exception:` without re-raise.
+
+- **Comments:** inline only for non-obvious logic. No dashed-line block headers.
+
+- **PEP 8:** line length 88.
+
+- **Logging:** use loguru. Import as `from loguru import logger`. Log at appropriate levels: `debug` for development, `info` for key events, `warning` for recoverable issues, `error` for failures.
+
+## Test Standards
+
+- Tests mirror `pyprobe/` structure in `tests/` directory.
+- Write tests with pytest. Cover expected behavior and edge cases for all public functions.
+- One logical behaviour per test function. Name tests as `test_<unit>_<scenario>_<expected>` (e.g., `test_cell_filter_empty_result_raises_error`).
+- Keep tests independent; use pytest fixtures for shared setup.
+- Use `@pytest.mark.parametrize` for multiple inputs instead of duplicating test bodies.
+- Use `tmp_path` fixture for temporary files; never `tempfile` directly.
+- Simple synthesised test data should be used where possible; real-format sample files in `tests/sample_data/` where required.
+
+## Commit Messages
+
+Use [Angular commit style](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits).
+
+## Before Opening a Pull Request
+
+Pre-commit checks will run automatically. You can invoke them manually with:
 ```bash
-$ uv run pytest
+uvx pre-commit run --all-files
 ```
 
-6. Ensure that the examples run to completion:
+Build docs:
 ```bash
-$ uv run pytest --nbmake docs/source/examples/*.ipynb
+cd docs && make html
 ```
 
-7. Open a pull request. In the pull request description, please describe in detail the changes your feature branch introduces, and reference the associated issue.
-
-## PyProBE structure
-Additions to the code should be made in accordance with the structure of PyProBE, to 
-maximise compatibility and ensure it is a maintainable package. Guidance for writing
-code for PyProBE includes:
-1. DataFrame operations should only be done using polars expressions. Data should be kept by default in polars LazyFrame format and only converted to DataFrame if needed for a particular operation.
-2. Analysis classes should be written in the format described in the [documentation](https://pyprobe.readthedocs.io/en/latest/developer_guide/contributing_to_the_analysis_module.html).
-
-## Linting and Style Guidelines
-PyProBE uses [Ruff](https://docs.astral.sh/ruff/) to check and format code against Python standards and good practise.
-It is able to automatically restyle your code and can make many automatic fixes for you. It 
-runs as a pre-commit hook, meaning it should pass before you commit to PyProBE. To reduce 
-the burden of making a large amount of fixes, be sure to make regular commits. You can also run:
+Run tests:
 ```bash
-uvx ruff check --fix
+uv run pytest
+uv run pytest --nbmake docs/source/examples/*.ipynb
 ```
-from the command line at any point. This will load the latest version of Ruff and run its checks, 
-making automatic fixes where possible.
 
-PyProBE also uses [mypy](https://mypy.readthedocs.io/en/stable/index.html) to check that
-all functions are correctly type hinted. Again, this runs as a pre-commit hook. It is
-likely that your code will use types already commonly used in PyProBE, so you may refer
-to existing code for how to type hint your functions.
+## Pull Request
 
-## Viewing the API documentation
-
-API documentation is built in html format, and stored locally in docs/build/html/. This can be viewed in your browser at docs/build/html/index.html.
-
-The documentation is also continuously deployed via GitHub Actions, and can be viewed [here](https://pyprobe.readthedocs.io).
+Describe changes in detail and reference the associated issue.

--- a/docs/source/examples/filtering-data.ipynb
+++ b/docs/source/examples/filtering-data.ipynb
@@ -228,7 +228,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Some cyclers will split constant voltage and constant current instructions into two separate steps. That is not the case for the cycler used for this dataset, but we can still extract them with PyProBE filtering:"
+    "Some cyclers will split constant voltage and constant current instructions into two separate steps. That is not the case for the cycler used for this dataset, but we can still extract them with PyProBE filtering. While it is an optional argument, it is recommended to provide a target voltage to filter by."
    ]
   },
   {
@@ -237,9 +237,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "CC_discharge = discharge.constant_current(0)\n",
-    "CC_charge = charge.constant_current(0)\n",
-    "CV_hold = cycle_3.constant_voltage(0)\n",
+    "CC_discharge = discharge.constant_current(0, target=-0.004)\n",
+    "CC_charge = charge.constant_current(0, target=0.004)\n",
+    "CV_hold = cycle_3.constant_voltage(0, target=4.2)\n",
     "\n",
     "fig, ax = plt.subplots()\n",
     "cycle_3.plot(\n",
@@ -271,6 +271,71 @@
     "    label=\"CV Hold\",\n",
     ")\n",
     "ax.set_ylabel(\"Current [A]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Depending on the cycler manufacturer, steps sometimes miss the first datapoint needed for your analysis. An optional boolean argument allows you to include this point in the filter result:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    fig,\n",
+    "    ax,\n",
+    ") = plt.subplots()\n",
+    "full_procedure.experiment(\"Discharge Pulses\").cycle(2).rest(\n",
+    "    1, include_preceding_point=True\n",
+    ").plot(\n",
+    "    x=\"Experiment Time [s]\", y=\"Voltage [V]\", ax=ax, label=\"Rest 1 with preceding point\"\n",
+    ")\n",
+    "full_procedure.experiment(\"Discharge Pulses\").cycle(2).rest(1).plot(\n",
+    "    x=\"Experiment Time [s]\",\n",
+    "    y=\"Voltage [V]\",\n",
+    "    ax=ax,\n",
+    "    label=\"Rest 1 without preceding point\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For looping in python `iter_*` versions of all the filters are provided. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for idx, discharg_i in enumerate(break_in.iter_discharge(range(3))):\n",
+    "    print(f\"Discharge {idx}: {discharg_i.capacity}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can iterate freely without specifying an endpoint, but this has a small performance penalty as part of the data must be resolved into memory to identify the endpoint. See the [maximising-performance                             \n",
+    "  notebook](./maximising-performance.ipynb) notebook for more detail on PyProBE's lazy backend."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for idx, discharg_i in enumerate(break_in.iter_discharge()):\n",
+    "    print(f\"Discharge {idx}: {discharg_i.capacity}\")"
    ]
   }
  ],

--- a/pyprobe/analysis/cycling.py
+++ b/pyprobe/analysis/cycling.py
@@ -77,7 +77,7 @@ def summary(input_data: FilterToCycleType, dchg_before_chg: bool = True) -> Resu
         lf_capacity_throughput.join(lf_time, on="Cycle", how="outer_coalesce")
         .join(lf_charge, on="Cycle", how="outer_coalesce")
         .join(lf_discharge, on="Cycle", how="outer_coalesce")
-    )
+    ).sort("Cycle")
 
     lf = lf.with_columns(
         (pl.col("Charge Capacity [Ah]") / pl.first("Charge Capacity [Ah]") * 100).alias(
@@ -120,7 +120,7 @@ def summary(input_data: FilterToCycleType, dchg_before_chg: bool = True) -> Resu
         ),
     }
     return Result(
-        lf=lf.sort("Cycle"),
+        lf=lf,
         info=input_data.info,
         column_definitions=column_definitions,
     )

--- a/pyprobe/analysis/cycling.py
+++ b/pyprobe/analysis/cycling.py
@@ -120,7 +120,7 @@ def summary(input_data: FilterToCycleType, dchg_before_chg: bool = True) -> Resu
         ),
     }
     return Result(
-        lf=lf,
+        lf=lf.sort("Cycle"),
         info=input_data.info,
         column_definitions=column_definitions,
     )

--- a/pyprobe/filters.py
+++ b/pyprobe/filters.py
@@ -1,6 +1,7 @@
 """A module for the filtering classes."""
 
 import warnings
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, cast
 
 import polars as pl
@@ -9,8 +10,7 @@ from pyprobe import utils
 from pyprobe.rawdata import RawData
 
 if TYPE_CHECKING:
-    from pyprobe.pyprobe_types import (  # , FilterToStepType
-        ExperimentOrCycleType,
+    from pyprobe.pyprobe_types import (
         FilterToCycleType,
     )
 
@@ -18,85 +18,359 @@ if TYPE_CHECKING:
 from loguru import logger
 
 
-def _filter_numerical(
-    dataframe: pl.LazyFrame | pl.DataFrame,
-    column: str,
-    indices: tuple[int | range, ...],
-) -> pl.LazyFrame | pl.DataFrame:
-    """Filter a polars Lazyframe or Dataframe by a numerical condition.
+def _extend_mask_with_preceding_point(mask: pl.Expr) -> pl.Expr:
+    """Extend a boolean mask to include the row immediately before the first True row.
 
     Args:
-        dataframe (pl.LazyFrame | pl.DataFrame): A LazyFrame or DataFrame to filter.
-        column (str): The column to filter on.
-        indices (Tuple[Union[int, range], ...]): A tuple of index values to filter by.
+        mask: A boolean polars expression.
 
     Returns:
-        pl.LazyFrame | pl.DataFrame: A filtered LazyFrame or DataFrame.
+        pl.Expr: The mask OR'd with itself shifted up by one position.
+    """
+    return mask | mask.shift(-1).fill_null(False)
+
+
+def _make_group_marker_expr(column: str, condition: pl.Expr) -> pl.Expr:
+    """Return a boolean expression that is True on the first row of each matching group.
+
+    Args:
+        column: The column to compute rank groups on.
+        condition: Expression selecting rows that belong to matching groups.
+
+    Returns:
+        pl.Expr: Boolean expression True at the start of each matching group.
+    """
+    event_rank = pl.col(column).rank("dense")
+    last_matching_event_rank = (
+        pl.when(condition).then(event_rank).otherwise(None).forward_fill()
+    )
+    return condition & (event_rank != last_matching_event_rank.shift().fill_null(-1))
+
+
+def _count_condition_groups(
+    lf: pl.LazyFrame | pl.DataFrame,
+    column: str,
+    condition: pl.Expr | None = None,
+) -> int:
+    """Count the number of distinct groups in lf, optionally within a condition.
+
+    Performs a single lightweight ``.collect()`` — collects only an integer,
+    not row data.
+
+    Args:
+        lf: The LazyFrame or DataFrame to inspect.
+        column: Column whose rank groups are counted.
+        condition: When supplied, only groups where this expression is True
+            are counted.
+
+    Returns:
+        int: Number of distinct groups.
+    """
+    lazy = lf.lazy() if isinstance(lf, pl.DataFrame) else lf
+    if condition is None:
+        return lazy.select(pl.col(column).n_unique()).collect().item()
+
+    is_new_matching_event = _make_group_marker_expr(column, condition)
+    return lazy.select(is_new_matching_event.cast(pl.Int32).sum()).collect().item()
+
+
+class Filter:
+    """Encapsulates group-filtering logic for a single column and optional condition."""
+
+    def __init__(self, column: str = "Event", condition: pl.Expr | None = None) -> None:
+        """Initialize a Filter instance.
+
+        Args:
+            column: The column name to perform filtering on. Defaults to "Event".
+            condition: Optional polars expression that defines which rows
+                qualify as part of a group. When ``None``, all rows in each
+                group are selected.
+        """
+        self.column = column
+        self.condition = condition
+
+    def _build_mask(self, indices: tuple[int | range | slice, ...]) -> pl.Expr:
+        """Build a boolean polars expression selecting rows by positional indices.
+
+        Supports positive and negative indexing, ranges, and slices.
+        Handles both absolute group ranks and relative indexing from the end.
+
+        Args:
+            indices: Tuple of int, range, or slice objects selecting groups
+                by position (zero-based).
+
+        Returns:
+            pl.Expr: A boolean polars expression where ``True`` indicates
+                rows that should be included in the result.
+        """
+        if len(indices) == 0:
+            return self.condition if self.condition is not None else pl.lit(True)
+
+        normalized_indices: list[int | slice] = []
+        has_negative = False
+        for idx in indices:
+            if isinstance(idx, int):
+                normalized_indices.append(idx)
+                if idx < 0:
+                    has_negative = True
+            elif isinstance(idx, range):
+                normalized_indices.append(slice(idx.start, idx.stop, idx.step))
+                if idx.start < 0 or idx.stop < 0:
+                    has_negative = True
+            elif isinstance(idx, slice):
+                normalized_indices.append(idx)
+                if (idx.start is not None and idx.start < 0) or (
+                    idx.stop is not None and idx.stop < 0
+                ):
+                    has_negative = True
+
+        if self.condition is not None:
+            is_new_matching_event = _make_group_marker_expr(self.column, self.condition)
+            asc_rank = is_new_matching_event.cast(pl.Int32).cum_sum()
+            if has_negative:
+                total_groups = is_new_matching_event.cast(pl.Int32).sum()
+                cond_desc_rank = total_groups - asc_rank + 1
+            else:
+                cond_desc_rank = None
+        else:
+            asc_rank = pl.col(self.column).rank("dense")
+            cond_desc_rank = (
+                pl.col(self.column).rank("dense", descending=True)
+                if has_negative
+                else None
+            )
+
+        sub_masks: list[pl.Expr] = []
+        for idx in normalized_indices:
+            if isinstance(idx, int):
+                if idx >= 0:
+                    sub_masks.append(asc_rank == idx + 1)
+                else:
+                    sub_masks.append(cond_desc_rank == -idx)
+            else:
+                sub_masks.append(_slice_to_mask_expr(idx, asc_rank, cond_desc_rank))
+
+        if not sub_masks:
+            return self.condition if self.condition is not None else pl.lit(True)
+
+        combined: pl.Expr = sub_masks[0]
+        for m in sub_masks[1:]:
+            combined = combined | m
+
+        return (self.condition & combined) if self.condition is not None else combined
+
+    def _expand_positions(
+        self,
+        lf: pl.LazyFrame,
+        indices: tuple[int | range | slice, ...],
+    ) -> list[int]:
+        """Expand positional indices (int, range, slice) to a flat list of integers.
+
+        Resolves negative indices and slices relative to the total number
+        of groups in the condition.
+
+        Args:
+            lf: The polars LazyFrame or DataFrame to inspect for group count.
+            indices: Tuple of int, range, or slice objects.
+
+        Returns:
+            list[int]: Flattened list of integer positions (zero-based).
+
+        Raises:
+            ValueError: If a slice has a negative step.
+            TypeError: If an unsupported index type is encountered.
+        """
+        if not indices:
+            return list(range(_count_condition_groups(lf, self.column, self.condition)))
+
+        positions: list[int] = []
+        total: int | None = None
+
+        def get_total() -> int:
+            nonlocal total
+            if total is None:
+                total = _count_condition_groups(lf, self.column, self.condition)
+            return total
+
+        for idx in indices:
+            if isinstance(idx, int):
+                positions.append(idx)
+            elif isinstance(idx, range):
+                positions.extend(idx)
+            elif isinstance(idx, slice):
+                if idx.step is not None and idx.step < 0:
+                    raise ValueError("Negative step is not supported in a slice index.")
+                step_val = idx.step if idx.step is not None else 1
+                start = idx.start if idx.start is not None else 0
+                if start >= 0 and idx.stop is not None and idx.stop >= 0:
+                    positions.extend(range(start, idx.stop, step_val))
+                else:
+                    positions.extend(range(*idx.indices(get_total())))
+            else:
+                raise TypeError(f"Unsupported index type: {type(idx).__name__}")
+        return positions
+
+    def _create_result(
+        self,
+        obj: "FilterToCycleType",
+        lf: pl.LazyFrame | pl.DataFrame,
+        mask: pl.Expr,
+        include_preceding_point: bool,
+    ) -> "Cycle | Step":
+        """Create a filtered result object (Cycle or Step).
+
+        Applies the mask to the data and returns the appropriate result type
+        based on the filter's column.
+
+        Args:
+            obj: The source object (Procedure, Experiment, Cycle, or Step).
+            lf: The polars LazyFrame or DataFrame to filter.
+            mask: Boolean expression selecting rows to include.
+            include_preceding_point: When ``True``, include the row immediately
+                before the first selected row in the result.
+
+        Returns:
+            Cycle | Step: A new Cycle or Step object containing the filtered data.
+        """
+        if include_preceding_point:
+            mask = _extend_mask_with_preceding_point(mask)
+
+        filtered_lf = lf.filter(mask)
+        if self.column == "Cycle":
+            cycle_info = obj.cycle_info[1:] if len(obj.cycle_info) > 1 else []
+            return Cycle(
+                lf=filtered_lf,
+                info=obj.info,
+                column_definitions=obj.column_definitions,
+                step_descriptions=obj.step_descriptions,
+                cycle_info=cycle_info,
+            )
+        return Step(
+            lf=filtered_lf,
+            info=obj.info,
+            column_definitions=obj.column_definitions,
+            step_descriptions=obj.step_descriptions,
+        )
+
+    def singular(
+        self,
+        obj: "FilterToCycleType",
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> "Cycle | Step":
+        """Return a single filtered result for the given indices.
+
+        Args:
+            obj: The source object to filter.
+            *indices: Positional selectors (int, range, or slice).
+            include_preceding_point: When ``True``, include the row immediately
+                before the first selected row.
+
+        Returns:
+            Cycle | Step: A single filtered result object.
+        """
+        lf = get_cycle_column(obj) if self.column == "Cycle" else obj.lf
+        mask = self._build_mask(indices)
+        return self._create_result(obj, lf, mask, include_preceding_point)
+
+    def plural(
+        self,
+        obj: "FilterToCycleType",
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> Iterator["Cycle | Step"]:
+        """Iterate over filtered results for each selected index.
+
+        Expands indices to individual positions and yields a result object
+        for each position.
+
+        Args:
+            obj: The source object to filter.
+            *indices: Positional selectors (int, range, or slice).
+            include_preceding_point: When ``True``, include the row immediately
+                before the first selected row in each result.
+
+        Yields:
+            Cycle | Step: Filtered result objects, one per selected position.
+        """
+        lf = get_cycle_column(obj) if self.column == "Cycle" else obj.lf
+        for i in self._expand_positions(lf, indices):
+            mask = self._build_mask((i,))
+            yield self._create_result(obj, lf, mask, include_preceding_point)
+
+
+def _slice_to_mask_expr(
+    s: slice,
+    asc_rank: pl.Expr,
+    desc_rank: pl.Expr | None,
+) -> pl.Expr:
+    """Convert a slice to a polars boolean expression using rank expressions.
+
+    Args:
+        s: The slice to convert. Negative step raises ``ValueError``.
+        asc_rank: Ascending rank expression for the target column.
+        desc_rank: Descending rank expression for the target column.
+            Required if ``s.start`` or ``s.stop`` are negative.
+
+    Returns:
+        pl.Expr: Boolean expression selecting rows matched by the slice.
 
     Raises:
-        ValueError: If indices are not all positive or all negative.
+        ValueError: If ``s.step`` is negative or if negative bounds are used
+            without a ``desc_rank``.
     """
-    index_list = []
-    for index in indices:
-        if isinstance(index, range):
-            index_list.extend(list(index))
+    if s.step is not None and s.step < 0:
+        error_msg = "Negative step is not supported in a slice index."
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+
+    parts: list[pl.Expr] = []
+
+    if s.start is not None:
+        if s.start >= 0:
+            parts.append(asc_rank >= s.start + 1)
         else:
-            index_list.extend([index])
+            if desc_rank is None:
+                raise ValueError("Negative slice start requires a descending rank.")
+            parts.append(desc_rank <= -s.start)
 
-    if len(index_list) > 0:
-        if all(item >= 0 for item in index_list):
-            index_list = [item + 1 for item in index_list]
-            return dataframe.filter(pl.col(column).rank("dense").is_in(index_list))
-        elif all(item < 0 for item in index_list):
-            index_list = [item * -1 for item in index_list]
-            return dataframe.filter(
-                pl.col(column).rank("dense", descending=True).is_in(index_list),
-            )
+    if s.stop is not None:
+        if s.stop > 0:
+            parts.append(asc_rank <= s.stop)
+        elif s.stop < 0:
+            if desc_rank is None:
+                raise ValueError("Negative slice stop requires a descending rank.")
+            parts.append(desc_rank > -s.stop)
+        else:  # s.stop == 0
+            if s.start is not None and s.start < 0:
+                # slice(-n, 0) is treated as slice(-n, None): no upper bound,
+                # matching Python's convention that stop=0 with a negative start
+                # is open-ended when the caller intends "from -n to end".
+                pass
+            else:
+                # asc_rank starts at 1, so <= 0 is always False → empty result,
+                # matching slice(0, 0) / slice(k, 0) for k >= 0.
+                parts.append(asc_rank <= 0)
+
+    step_val = s.step
+    if step_val is not None and step_val > 1:
+        effective_start = s.start if s.start is not None else 0
+        if effective_start >= 0:
+            anchor = effective_start + 1
+            parts.append((asc_rank - anchor) % step_val == 0)
         else:
-            error_msg = "Indices must be all positive or all negative."
-            logger.error(error_msg)
-            raise ValueError(error_msg)
-    else:
-        return dataframe
+            if desc_rank is None:
+                raise ValueError("Negative slice start requires a descending rank.")
+            anchor = -effective_start
+            parts.append((anchor - desc_rank) % step_val == 0)
 
+    if not parts:
+        return pl.lit(True)
 
-def _step(
-    filtered_object: "FilterToCycleType",
-    *step_numbers: int | range,
-    condition: pl.Expr | None = None,
-) -> "Step":
-    """Return a step object. Filters to a numerical condition on the Event column.
-
-    Args:
-        filtered_object (FilterToCycleType):
-            A filter object that this method is called on.
-        step_numbers (int | range):
-            Variable-length argument list of step indices or a range object.
-        condition (pl.Expr, optional):
-            A polars expression to filter the step before applying the numerical filter.
-            Defaults to None.
-
-    Returns:
-        Step: A step object.
-    """
-    if condition is not None:
-        lf = _filter_numerical(
-            filtered_object.lf.filter(condition),
-            "Event",
-            step_numbers,
-        )
-    else:
-        lf = _filter_numerical(
-            filtered_object.lf,
-            "Event",
-            step_numbers,
-        )
-    return Step(
-        lf=lf,
-        info=filtered_object.info,
-        column_definitions=filtered_object.column_definitions,
-        step_descriptions=filtered_object.step_descriptions,
-    )
+    result: pl.Expr = parts[0]
+    for p in parts[1:]:
+        result = result & p
+    return result
 
 
 def get_cycle_column(
@@ -138,168 +412,468 @@ def get_cycle_column(
     return filtered_object.lf.with_columns(cycle_column)
 
 
-def _cycle(filtered_object: "ExperimentOrCycleType", *cycle_numbers: int) -> "Cycle":
-    """Return a cycle object. Filters on the Cycle column.
-
-    Args:
-        filtered_object (FilterToExperimentType):
-            A filter object that this method is called on.
-        cycle_numbers (int | range):
-            Variable-length argument list of cycle indices or a range object.
-
-    Returns:
-        Cycle: A cycle object.
-    """
-    df = get_cycle_column(filtered_object)
-
-    if len(filtered_object.cycle_info) > 1:
-        next_cycle_info = filtered_object.cycle_info[1:]
-    else:
-        next_cycle_info = []
-
-    lf_filtered = _filter_numerical(df, "Cycle", cycle_numbers)
-
-    return Cycle(
-        lf=lf_filtered,
-        info=filtered_object.info,
-        column_definitions=filtered_object.column_definitions,
-        step_descriptions=filtered_object.step_descriptions,
-        cycle_info=next_cycle_info,
+_step_f = Filter("Event")
+_cycle_f = Filter("Cycle")
+_charge_f = Filter(
+    "Event", pl.col("Current [A]") > pl.col("Current [A]").abs().max() / 10e4
+)
+_discharge_f = Filter(
+    "Event", pl.col("Current [A]") < -pl.col("Current [A]").abs().max() / 10e4
+)
+_chargeordischarge_f = Filter(
+    "Event", pl.col("Current [A]").abs() > pl.col("Current [A]").abs().max() / 10e4
+)
+_rest_f = Filter("Event", pl.col("Current [A]") == 0)
+_cc_f = Filter(
+    "Event",
+    (pl.col("Current [A]") != 0)
+    & (
+        pl.col("Current [A]").abs()
+        > 0.999 * pl.col("Current [A]").abs().round_sig_figs(4).mode().first()
     )
-
-
-def _charge(
-    filtered_object: "FilterToCycleType",
-    *charge_numbers: int | range,
-) -> "Step":
-    """Return a charge step.
-
-    Args:
-        filtered_object (FilterToCycleType):
-            A filter object that this method is called on.
-        charge_numbers (int | range):
-            Variable-length argument list of charge indices or a range object.
-
-    Returns:
-        Step: A charge step object.
-    """
-    condition = pl.col("Current [A]") > pl.col("Current [A]").abs().max() / 10e4
-    return filtered_object.step(*charge_numbers, condition=condition)
-
-
-def _discharge(
-    filtered_object: "FilterToCycleType",
-    *discharge_numbers: int | range,
-) -> "Step":
-    """Return a discharge step.
-
-    Args:
-        filtered_object (FilterToCycleType):
-            A filter object that this method is called on.
-        discharge_numbers (int | range):
-            Variable-length argument list of discharge indices or a range object.
-
-    Returns:
-        Step: A discharge step object.
-    """
-    condition = pl.col("Current [A]") < -pl.col("Current [A]").abs().max() / 10e4
-    return filtered_object.step(*discharge_numbers, condition=condition)
-
-
-def _chargeordischarge(
-    filtered_object: "FilterToCycleType",
-    *chargeordischarge_numbers: int | range,
-) -> "Step":
-    """Return a charge or discharge step.
-
-    Args:
-        filtered_object (FilterToCycleType):
-            A filter object that this method is called on.
-        chargeordischarge_numbers (int | range):
-            Variable-length argument list of charge or discharge indices or a range
-            object.
-
-    Returns:
-        Step: A charge or discharge step object.
-    """
-    charge_condition = pl.col("Current [A]") > pl.col("Current [A]").abs().max() / 10e4
-    discharge_condition = (
-        pl.col("Current [A]") < -pl.col("Current [A]").abs().max() / 10e4
-    )
-    condition = charge_condition | discharge_condition
-    return filtered_object.step(*chargeordischarge_numbers, condition=condition)
-
-
-def _rest(filtered_object: "FilterToCycleType", *rest_numbers: int | range) -> "Step":
-    """Return a rest step object.
-
-    Args:
-        filtered_object (FilterToCycleType):
-            A filter object that this method is called on.
-        rest_numbers (int | range):
-            Variable-length argument list of rest indices or a range object.
-
-    Returns:
-        Step: A rest step object.
-    """
-    condition = pl.col("Current [A]") == 0
-    return filtered_object.step(*rest_numbers, condition=condition)
-
-
-def _constant_current(
-    filtered_object: "FilterToCycleType",
-    *constant_current_numbers: int | range,
-) -> "Step":
-    """Return a constant current step object.
-
-    Args:
-        filtered_object (FilterToCycleType):
-            A filter object that this method is called on.
-        constant_current_numbers (int | range):
-            Variable-length argument list of constant current indices or a range object.
-
-    Returns:
-        Step: A constant current step object.
-    """
-    condition = (
-        (pl.col("Current [A]") != 0)
-        & (
-            pl.col("Current [A]").abs()
-            > 0.999 * pl.col("Current [A]").abs().round_sig_figs(4).mode()
-        )
-        & (
-            pl.col("Current [A]").abs()
-            < 1.001 * pl.col("Current [A]").abs().round_sig_figs(4).mode()
-        )
-    )
-    return filtered_object.step(*constant_current_numbers, condition=condition)
-
-
-def _constant_voltage(
-    filtered_object: "FilterToCycleType",
-    *constant_voltage_numbers: int | range,
-) -> "Step":
-    """Return a constant voltage step object.
-
-    Args:
-        filtered_object: A filter object that this method is called on.
-        *constant_voltage_numbers:
-            Variable-length argument list of constant voltage indices or a range object.
-
-    Returns:
-        Step: A constant voltage step object.
-    """
-    condition = (
+    & (
+        pl.col("Current [A]").abs()
+        < 1.001 * pl.col("Current [A]").abs().round_sig_figs(4).mode().first()
+    ),
+)
+_cv_f = Filter(
+    "Event",
+    (
         pl.col("Voltage [V]").abs()
-        > 0.999 * pl.col("Voltage [V]").abs().round_sig_figs(4).mode()
-    ) & (
-        pl.col("Voltage [V]").abs()
-        < 1.001 * pl.col("Voltage [V]").abs().round_sig_figs(4).mode()
+        > 0.999 * pl.col("Voltage [V]").abs().round_sig_figs(4).mode().first()
     )
-    return filtered_object.step(*constant_voltage_numbers, condition=condition)
+    & (
+        pl.col("Voltage [V]").abs()
+        < 1.001 * pl.col("Voltage [V]").abs().round_sig_figs(4).mode().first()
+    ),
+)
 
 
-class Procedure(RawData):
+class StepFiltersMixin:
+    """Mixin providing step-specific filter methods."""
+
+    def step(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> "Step":
+        """Filter step events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Step: Filtered result for the selected groups.
+        """
+        return cast(
+            "Step",
+            _step_f.singular(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def iter_step(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> Iterator["Step"]:
+        """Iterate over step events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Iterator[Step]: Filtered result for the selected groups.
+        """
+        return cast(
+            Iterator["Step"],
+            _step_f.plural(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def constant_current(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> "Step":
+        """Filter constant-current events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Step: Filtered result for the selected groups.
+        """
+        return cast(
+            "Step",
+            _cc_f.singular(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def iter_constant_current(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> Iterator["Step"]:
+        """Iterate over constant-current events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Iterator[Step]: Filtered result for the selected groups.
+        """
+        return cast(
+            Iterator["Step"],
+            _cc_f.plural(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def constant_voltage(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> "Step":
+        """Filter constant-voltage events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Step: Filtered result for the selected groups.
+        """
+        return cast(
+            "Step",
+            _cv_f.singular(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def iter_constant_voltage(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> Iterator["Step"]:
+        """Iterate over constant-voltage events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Iterator[Step]: Filtered result for the selected groups.
+        """
+        return cast(
+            Iterator["Step"],
+            _cv_f.plural(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+
+class CycleFiltersMixin:
+    """Mixin providing cycle and charge/discharge filter methods."""
+
+    def cycle(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> "Cycle":
+        """Filter cycles selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Cycle: Filtered result for the selected groups.
+        """
+        return cast(
+            "Cycle",
+            _cycle_f.singular(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def iter_cycle(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> Iterator["Cycle"]:
+        """Iterate over cycles selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Iterator[Cycle]: Filtered result for the selected groups.
+        """
+        return cast(
+            Iterator["Cycle"],
+            _cycle_f.plural(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def charge(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> "Step":
+        """Filter charge events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Step: Filtered result for the selected groups.
+        """
+        return cast(
+            "Step",
+            _charge_f.singular(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def iter_charge(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> Iterator["Step"]:
+        """Iterate over charge events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Iterator[Step]: Filtered result for the selected groups.
+        """
+        return cast(
+            Iterator["Step"],
+            _charge_f.plural(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def discharge(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> "Step":
+        """Filter discharge events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Step: Filtered result for the selected groups.
+        """
+        return cast(
+            "Step",
+            _discharge_f.singular(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def iter_discharge(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> Iterator["Step"]:
+        """Iterate over discharge events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Iterator[Step]: Filtered result for the selected groups.
+        """
+        return cast(
+            Iterator["Step"],
+            _discharge_f.plural(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def chargeordischarge(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> "Step":
+        """Filter non-rest events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Step: Filtered result for the selected groups.
+        """
+        return cast(
+            "Step",
+            _chargeordischarge_f.singular(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def iter_chargeordischarge(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> Iterator["Step"]:
+        """Iterate over non-rest events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Iterator[Step]: Filtered result for the selected groups.
+        """
+        return cast(
+            Iterator["Step"],
+            _chargeordischarge_f.plural(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def rest(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> "Step":
+        """Filter rest events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Step: Filtered result for the selected groups.
+        """
+        return cast(
+            "Step",
+            _rest_f.singular(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+    def iter_rest(
+        self,
+        *indices: int | range | slice,
+        include_preceding_point: bool = False,
+    ) -> Iterator["Step"]:
+        """Iterate over rest events selected by positional indices.
+
+        Args:
+            *indices (int | range | slice): Positional selectors for groups.
+                Supports zero-based integers, ranges, and slices, including
+                negative indexing relative to the end.
+            include_preceding_point (bool): When ``True``, include the data
+                row immediately before the first selected row.
+
+        Returns:
+            Iterator[Step]: Filtered result for the selected groups.
+        """
+        return cast(
+            Iterator["Step"],
+            _rest_f.plural(
+                cast("FilterToCycleType", self),
+                *indices,
+                include_preceding_point=include_preceding_point,
+            ),
+        )
+
+
+class Procedure(CycleFiltersMixin, StepFiltersMixin, RawData):
     """A class for a procedure in a battery experiment."""
 
     readme_dict: dict[str, dict[str, list[str | int | tuple[int, int, int]]]]
@@ -338,21 +912,17 @@ class Procedure(RawData):
             self.step_descriptions["Step"].extend(steps)
             self.step_descriptions["Description"].extend(descriptions)
 
-    step = _step
-    cycle = _cycle
-    charge = _charge
-    discharge = _discharge
-    chargeordischarge = _chargeordischarge
-    rest = _rest
-    constant_current = _constant_current
-    constant_voltage = _constant_voltage
-
-    def experiment(self, *experiment_names: str) -> "Experiment":
+    def experiment(
+        self,
+        *experiment_names: str,
+        include_preceding_point: bool = False,
+    ) -> "Experiment":
         """Return an experiment object from the procedure.
 
         Args:
-            experiment_names (str):
-                Variable-length argument list of experiment names.
+            experiment_names: Variable-length argument list of experiment names.
+            include_preceding_point: When ``True``, prepend the data point
+                immediately before the experiment's first row.
 
         Returns:
             Experiment: An experiment object from the procedure.
@@ -365,10 +935,10 @@ class Procedure(RawData):
                 raise ValueError(error_msg)
             steps_idx.append(self.readme_dict[experiment_name]["Steps"])
         flattened_steps = utils.flatten_list(steps_idx)
-        conditions = [
-            pl.col("Step").is_in(flattened_steps),
-        ]
-        lf_filtered = self.lf.filter(conditions)
+        mask = pl.col("Step").is_in(flattened_steps)
+        if include_preceding_point:
+            mask = _extend_mask_with_preceding_point(mask)
+        lf_filtered = self.lf.filter(mask)
         cycles_list: list[tuple[int, int, int]] = []
         if len(experiment_names) > 1:
             warnings.warn(
@@ -456,7 +1026,7 @@ class Procedure(RawData):
         self.add_new_data_columns(external_data, date_column_name)
 
 
-class Experiment(RawData):
+class Experiment(CycleFiltersMixin, StepFiltersMixin, RawData):
     """A class for an experiment in a battery experimental procedure."""
 
     cycle_info: list[tuple[int, int, int]] = []
@@ -481,17 +1051,8 @@ class Experiment(RawData):
             "The net charge passed since beginning of experiment.",
         )
 
-    step = _step
-    cycle = _cycle
-    charge = _charge
-    discharge = _discharge
-    chargeordischarge = _chargeordischarge
-    rest = _rest
-    constant_current = _constant_current
-    constant_voltage = _constant_voltage
 
-
-class Cycle(RawData):
+class Cycle(CycleFiltersMixin, StepFiltersMixin, RawData):
     """A class for a cycle in a battery experimental procedure."""
 
     cycle_info: list[tuple[int, int, int]] = []
@@ -516,16 +1077,8 @@ class Cycle(RawData):
             "The net charge passed since beginning of cycle.",
         )
 
-    step = _step
-    charge = _charge
-    discharge = _discharge
-    chargeordischarge = _chargeordischarge
-    rest = _rest
-    constant_current = _constant_current
-    constant_voltage = _constant_voltage
 
-
-class Step(RawData):
+class Step(StepFiltersMixin, RawData):
     """A class for a step in a battery experimental procedure."""
 
     def model_post_init(self, __context: Any) -> None:
@@ -542,7 +1095,3 @@ class Step(RawData):
             "Step Capacity [Ah]",
             "The net charge passed since beginning of step.",
         )
-
-    step = _step
-    constant_current = _constant_current
-    constant_voltage = _constant_voltage

--- a/pyprobe/filters.py
+++ b/pyprobe/filters.py
@@ -19,13 +19,14 @@ from loguru import logger
 
 
 def _extend_mask_with_preceding_point(mask: pl.Expr) -> pl.Expr:
-    """Extend a boolean mask to include the row immediately before the first True row.
+    """Extend a boolean mask to include the row preceding each contiguous True run.
 
     Args:
         mask: A boolean polars expression.
 
     Returns:
-        pl.Expr: The mask OR'd with itself shifted up by one position.
+        pl.Expr: A boolean expression that is True for every originally selected
+            row plus the row immediately before each run of selected rows.
     """
     return mask | mask.shift(-1).fill_null(False)
 
@@ -41,10 +42,10 @@ def _make_group_marker_expr(column: str, condition: pl.Expr) -> pl.Expr:
         pl.Expr: Boolean expression True at the start of each matching group.
     """
     event_rank = pl.col(column).rank("dense")
-    last_matching_event_rank = (
-        pl.when(condition).then(event_rank).otherwise(None).forward_fill()
+    prev_matching_rank = (
+        pl.when(condition).then(event_rank).otherwise(None).forward_fill().shift()
     )
-    return condition & (event_rank != last_matching_event_rank.shift().fill_null(-1))
+    return condition & (event_rank != prev_matching_rank.fill_null(-1))
 
 
 def _count_condition_groups(
@@ -67,11 +68,12 @@ def _count_condition_groups(
         int: Number of distinct groups.
     """
     lazy = lf.lazy() if isinstance(lf, pl.DataFrame) else lf
-    if condition is None:
-        return lazy.select(pl.col(column).n_unique()).collect().item()
-
-    is_new_matching_event = _make_group_marker_expr(column, condition)
-    return lazy.select(is_new_matching_event.cast(pl.Int32).sum()).collect().item()
+    count_expr = (
+        pl.col(column).n_unique()
+        if condition is None
+        else _make_group_marker_expr(column, condition).cast(pl.Int32).sum()
+    )
+    return lazy.select(count_expr).collect().item()
 
 
 class Filter:
@@ -227,7 +229,7 @@ class Filter:
             lf: The polars LazyFrame or DataFrame to filter.
             mask: Boolean expression selecting rows to include.
             include_preceding_point: When ``True``, include the row immediately
-                before the first selected row in the result.
+                before each contiguous block of selected rows.
 
         Returns:
             Cycle | Step: A new Cycle or Step object containing the filtered data.
@@ -264,7 +266,7 @@ class Filter:
             obj: The source object to filter.
             *indices: Positional selectors (int, range, or slice).
             include_preceding_point: When ``True``, include the row immediately
-                before the first selected row.
+                before each contiguous block of selected rows.
 
         Returns:
             Cycle | Step: A single filtered result object.
@@ -288,7 +290,7 @@ class Filter:
             obj: The source object to filter.
             *indices: Positional selectors (int, range, or slice).
             include_preceding_point: When ``True``, include the row immediately
-                before the first selected row in each result.
+                before the selected row in each result.
 
         Yields:
             Cycle | Step: Filtered result objects, one per selected position.
@@ -331,7 +333,9 @@ def _slice_to_mask_expr(
             parts.append(asc_rank >= s.start + 1)
         else:
             if desc_rank is None:
-                raise ValueError("Negative slice start requires a descending rank.")
+                error_msg = "Negative slice start requires a descending rank."
+                logger.error(error_msg)
+                raise ValueError(error_msg)
             parts.append(desc_rank <= -s.start)
 
     if s.stop is not None:
@@ -339,7 +343,9 @@ def _slice_to_mask_expr(
             parts.append(asc_rank <= s.stop)
         elif s.stop < 0:
             if desc_rank is None:
-                raise ValueError("Negative slice stop requires a descending rank.")
+                error_msg = "Negative slice stop requires a descending rank."
+                logger.error(error_msg)
+                raise ValueError(error_msg)
             parts.append(desc_rank > -s.stop)
         else:  # s.stop == 0
             if s.start is not None and s.start < 0:
@@ -360,7 +366,9 @@ def _slice_to_mask_expr(
             parts.append((asc_rank - anchor) % step_val == 0)
         else:
             if desc_rank is None:
-                raise ValueError("Negative slice start requires a descending rank.")
+                error_msg = "Negative slice start requires a descending rank."
+                logger.error(error_msg)
+                raise ValueError(error_msg)
             anchor = -effective_start
             parts.append((anchor - desc_rank) % step_val == 0)
 
@@ -471,7 +479,7 @@ class StepFiltersMixin:
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Step: Filtered result for the selected groups.
@@ -497,7 +505,7 @@ class StepFiltersMixin:
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Iterator[Step]: Filtered result for the selected groups.
@@ -536,7 +544,7 @@ class StepFiltersMixin:
                 ``0.001`` (0.1%). Near-zero targets collapse the band; use a
                 dedicated filter for rest steps instead.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Step: Filtered result for the selected groups.
@@ -578,7 +586,7 @@ class StepFiltersMixin:
                 ``0.001`` (0.1%). Near-zero targets collapse the band; use a
                 dedicated filter for rest steps instead.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Iterator[Step]: Filtered result for the selected groups.
@@ -619,7 +627,7 @@ class StepFiltersMixin:
                 acceptance band as a fraction of ``|target|``. Defaults to
                 ``0.001`` (0.1%).
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Step: Filtered result for the selected groups.
@@ -659,7 +667,7 @@ class StepFiltersMixin:
                 acceptance band as a fraction of ``|target|``. Defaults to
                 ``0.001`` (0.1%).
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Iterator[Step]: Filtered result for the selected groups.
@@ -691,7 +699,7 @@ class CycleFiltersMixin:
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Cycle: Filtered result for the selected groups.
@@ -717,7 +725,7 @@ class CycleFiltersMixin:
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Iterator[Cycle]: Filtered result for the selected groups.
@@ -743,7 +751,7 @@ class CycleFiltersMixin:
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Step: Filtered result for the selected groups.
@@ -769,7 +777,7 @@ class CycleFiltersMixin:
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Iterator[Step]: Filtered result for the selected groups.
@@ -795,7 +803,7 @@ class CycleFiltersMixin:
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Step: Filtered result for the selected groups.
@@ -821,7 +829,7 @@ class CycleFiltersMixin:
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Iterator[Step]: Filtered result for the selected groups.
@@ -847,7 +855,7 @@ class CycleFiltersMixin:
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Step: Filtered result for the selected groups.
@@ -873,7 +881,7 @@ class CycleFiltersMixin:
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Iterator[Step]: Filtered result for the selected groups.
@@ -899,7 +907,7 @@ class CycleFiltersMixin:
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Step: Filtered result for the selected groups.
@@ -925,7 +933,7 @@ class CycleFiltersMixin:
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
             include_preceding_point (bool): When ``True``, include the data
-                row immediately before the first selected row.
+                row immediately before each contiguous block of selected rows.
 
         Returns:
             Iterator[Step]: Filtered result for the selected groups.

--- a/pyprobe/filters.py
+++ b/pyprobe/filters.py
@@ -76,11 +76,11 @@ def _count_condition_groups(
     return lazy.select(count_expr).collect().item()
 
 
-class Filter:
+class _Filter:
     """Encapsulates group-filtering logic for a single column and optional condition."""
 
     def __init__(self, column: str = "Event", condition: pl.Expr | None = None) -> None:
-        """Initialize a Filter instance.
+        """Initialize a _Filter instance.
 
         Args:
             column: The column name to perform filtering on. Defaults to "Event".
@@ -420,18 +420,18 @@ def get_cycle_column(
     return filtered_object.lf.with_columns(cycle_column)
 
 
-_step_f = Filter("Event")
-_cycle_f = Filter("Cycle")
-_charge_f = Filter(
+_step_f = _Filter("Event")
+_cycle_f = _Filter("Cycle")
+_charge_f = _Filter(
     "Event", pl.col("Current [A]") > pl.col("Current [A]").abs().max() / 10e4
 )
-_discharge_f = Filter(
+_discharge_f = _Filter(
     "Event", pl.col("Current [A]") < -pl.col("Current [A]").abs().max() / 10e4
 )
-_chargeordischarge_f = Filter(
+_chargeordischarge_f = _Filter(
     "Event", pl.col("Current [A]").abs() > pl.col("Current [A]").abs().max() / 10e4
 )
-_rest_f = Filter("Event", pl.col("Current [A]") == 0)
+_rest_f = _Filter("Event", pl.col("Current [A]") == 0)
 
 
 def _make_constant_condition(
@@ -551,7 +551,7 @@ class StepFiltersMixin:
         """
         mask = pl.col("Current [A]") != 0 if target is None else None
         condition = _make_constant_condition("Current [A]", target, rtol, mask=mask)
-        f = Filter("Event", condition)
+        f = _Filter("Event", condition)
         return cast(
             "Step",
             f.singular(
@@ -593,7 +593,7 @@ class StepFiltersMixin:
         """
         mask = pl.col("Current [A]") != 0 if target is None else None
         condition = _make_constant_condition("Current [A]", target, rtol, mask=mask)
-        f = Filter("Event", condition)
+        f = _Filter("Event", condition)
         return cast(
             Iterator["Step"],
             f.plural(
@@ -633,7 +633,7 @@ class StepFiltersMixin:
             Step: Filtered result for the selected groups.
         """
         condition = _make_constant_condition("Voltage [V]", target, rtol)
-        f = Filter("Event", condition)
+        f = _Filter("Event", condition)
         return cast(
             "Step",
             f.singular(
@@ -673,7 +673,7 @@ class StepFiltersMixin:
             Iterator[Step]: Filtered result for the selected groups.
         """
         condition = _make_constant_condition("Voltage [V]", target, rtol)
-        f = Filter("Event", condition)
+        f = _Filter("Event", condition)
         return cast(
             Iterator["Step"],
             f.plural(

--- a/pyprobe/filters.py
+++ b/pyprobe/filters.py
@@ -424,29 +424,36 @@ _chargeordischarge_f = Filter(
     "Event", pl.col("Current [A]").abs() > pl.col("Current [A]").abs().max() / 10e4
 )
 _rest_f = Filter("Event", pl.col("Current [A]") == 0)
-_cc_f = Filter(
-    "Event",
-    (pl.col("Current [A]") != 0)
-    & (
-        pl.col("Current [A]").abs()
-        > 0.999 * pl.col("Current [A]").abs().round_sig_figs(4).mode().first()
-    )
-    & (
-        pl.col("Current [A]").abs()
-        < 1.001 * pl.col("Current [A]").abs().round_sig_figs(4).mode().first()
-    ),
-)
-_cv_f = Filter(
-    "Event",
-    (
-        pl.col("Voltage [V]").abs()
-        > 0.999 * pl.col("Voltage [V]").abs().round_sig_figs(4).mode().first()
-    )
-    & (
-        pl.col("Voltage [V]").abs()
-        < 1.001 * pl.col("Voltage [V]").abs().round_sig_figs(4).mode().first()
-    ),
-)
+
+
+def _make_constant_condition(
+    col: str,
+    target: float | None = None,
+    rtol: float = 0.001,
+    mask: pl.Expr | None = None,
+) -> pl.Expr:
+    """Return a polars expression selecting rows in a constant-value section.
+
+    Args:
+        col: Column name to evaluate (e.g. ``"Current [A]"`` or ``"Voltage [V]"``).
+        target: When supplied, selects rows where ``col`` lies within
+            ``target ± |target| * rtol``. Sign is preserved: a positive target
+            only matches positive values; a negative target only matches negative
+            values. When ``None``, the global mode of ``col`` (filtered by
+            ``mask`` if given) is used as the target.
+        rtol: Relative tolerance (dimensionless). The acceptance band around
+            the target is ``|target| * rtol``. Defaults to ``0.001`` (0.1%).
+        mask: Optional polars expression used to filter ``col`` before computing
+            the global mode (only used when ``target`` is ``None``).
+
+    Returns:
+        pl.Expr: Boolean expression that is True for rows in constant sections.
+    """
+    if target is not None:
+        return (pl.col(col) - target).abs() <= abs(target) * rtol
+    mode_expr = pl.col(col).filter(mask) if mask is not None else pl.col(col)
+    t = mode_expr.mode().first()
+    return (pl.col(col) - t).abs() <= t.abs() * rtol
 
 
 class StepFiltersMixin:
@@ -507,6 +514,8 @@ class StepFiltersMixin:
     def constant_current(
         self,
         *indices: int | range | slice,
+        target: float | None = None,
+        rtol: float = 0.001,
         include_preceding_point: bool = False,
     ) -> "Step":
         """Filter constant-current events selected by positional indices.
@@ -515,15 +524,29 @@ class StepFiltersMixin:
             *indices (int | range | slice): Positional selectors for groups.
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
+            target (float | None): When supplied, select only rows where
+                ``Current [A]`` lies within ``target ± |target| * rtol``. Sign
+                is preserved: ``target=1.0`` matches only positive (charge)
+                values; ``target=-1.0`` matches only negative (discharge)
+                values. When ``None``, the global mode of non-zero
+                ``Current [A]`` values is used as the target (backward-
+                compatible behaviour).
+            rtol (float): Relative tolerance (dimensionless) controlling the
+                acceptance band as a fraction of ``|target|``. Defaults to
+                ``0.001`` (0.1%). Near-zero targets collapse the band; use a
+                dedicated filter for rest steps instead.
             include_preceding_point (bool): When ``True``, include the data
                 row immediately before the first selected row.
 
         Returns:
             Step: Filtered result for the selected groups.
         """
+        mask = pl.col("Current [A]") != 0 if target is None else None
+        condition = _make_constant_condition("Current [A]", target, rtol, mask=mask)
+        f = Filter("Event", condition)
         return cast(
             "Step",
-            _cc_f.singular(
+            f.singular(
                 cast("FilterToCycleType", self),
                 *indices,
                 include_preceding_point=include_preceding_point,
@@ -533,6 +556,8 @@ class StepFiltersMixin:
     def iter_constant_current(
         self,
         *indices: int | range | slice,
+        target: float | None = None,
+        rtol: float = 0.001,
         include_preceding_point: bool = False,
     ) -> Iterator["Step"]:
         """Iterate over constant-current events selected by positional indices.
@@ -541,15 +566,29 @@ class StepFiltersMixin:
             *indices (int | range | slice): Positional selectors for groups.
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
+            target (float | None): When supplied, select only rows where
+                ``Current [A]`` lies within ``target ± |target| * rtol``. Sign
+                is preserved: ``target=1.0`` matches only positive (charge)
+                values; ``target=-1.0`` matches only negative (discharge)
+                values. When ``None``, the global mode of non-zero
+                ``Current [A]`` values is used as the target (backward-
+                compatible behaviour).
+            rtol (float): Relative tolerance (dimensionless) controlling the
+                acceptance band as a fraction of ``|target|``. Defaults to
+                ``0.001`` (0.1%). Near-zero targets collapse the band; use a
+                dedicated filter for rest steps instead.
             include_preceding_point (bool): When ``True``, include the data
                 row immediately before the first selected row.
 
         Returns:
             Iterator[Step]: Filtered result for the selected groups.
         """
+        mask = pl.col("Current [A]") != 0 if target is None else None
+        condition = _make_constant_condition("Current [A]", target, rtol, mask=mask)
+        f = Filter("Event", condition)
         return cast(
             Iterator["Step"],
-            _cc_f.plural(
+            f.plural(
                 cast("FilterToCycleType", self),
                 *indices,
                 include_preceding_point=include_preceding_point,
@@ -559,6 +598,8 @@ class StepFiltersMixin:
     def constant_voltage(
         self,
         *indices: int | range | slice,
+        target: float | None = None,
+        rtol: float = 0.001,
         include_preceding_point: bool = False,
     ) -> "Step":
         """Filter constant-voltage events selected by positional indices.
@@ -567,15 +608,27 @@ class StepFiltersMixin:
             *indices (int | range | slice): Positional selectors for groups.
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
+            target (float | None): When supplied, select only rows where
+                ``Voltage [V]`` lies within ``target ± |target| * rtol``. Sign
+                is preserved: a positive target only matches positive voltages.
+                When ``None``, the global mode of ``Voltage [V]`` is used as
+                the target (backward-compatible behaviour). Note: 0 V is a
+                valid CV target; the band collapses if ``target`` is exactly
+                zero — use a rest filter instead.
+            rtol (float): Relative tolerance (dimensionless) controlling the
+                acceptance band as a fraction of ``|target|``. Defaults to
+                ``0.001`` (0.1%).
             include_preceding_point (bool): When ``True``, include the data
                 row immediately before the first selected row.
 
         Returns:
             Step: Filtered result for the selected groups.
         """
+        condition = _make_constant_condition("Voltage [V]", target, rtol)
+        f = Filter("Event", condition)
         return cast(
             "Step",
-            _cv_f.singular(
+            f.singular(
                 cast("FilterToCycleType", self),
                 *indices,
                 include_preceding_point=include_preceding_point,
@@ -585,6 +638,8 @@ class StepFiltersMixin:
     def iter_constant_voltage(
         self,
         *indices: int | range | slice,
+        target: float | None = None,
+        rtol: float = 0.001,
         include_preceding_point: bool = False,
     ) -> Iterator["Step"]:
         """Iterate over constant-voltage events selected by positional indices.
@@ -593,15 +648,27 @@ class StepFiltersMixin:
             *indices (int | range | slice): Positional selectors for groups.
                 Supports zero-based integers, ranges, and slices, including
                 negative indexing relative to the end.
+            target (float | None): When supplied, select only rows where
+                ``Voltage [V]`` lies within ``target ± |target| * rtol``. Sign
+                is preserved: a positive target only matches positive voltages.
+                When ``None``, the global mode of ``Voltage [V]`` is used as
+                the target (backward-compatible behaviour). Note: 0 V is a
+                valid CV target; the band collapses if ``target`` is exactly
+                zero — use a rest filter instead.
+            rtol (float): Relative tolerance (dimensionless) controlling the
+                acceptance band as a fraction of ``|target|``. Defaults to
+                ``0.001`` (0.1%).
             include_preceding_point (bool): When ``True``, include the data
                 row immediately before the first selected row.
 
         Returns:
             Iterator[Step]: Filtered result for the selected groups.
         """
+        condition = _make_constant_condition("Voltage [V]", target, rtol)
+        f = Filter("Event", condition)
         return cast(
             Iterator["Step"],
-            _cv_f.plural(
+            f.plural(
                 cast("FilterToCycleType", self),
                 *indices,
                 include_preceding_point=include_preceding_point,

--- a/pyprobe/filters.py
+++ b/pyprobe/filters.py
@@ -365,10 +365,7 @@ def _slice_to_mask_expr(
             anchor = effective_start + 1
             parts.append((asc_rank - anchor) % step_val == 0)
         else:
-            if desc_rank is None:
-                error_msg = "Negative slice start requires a descending rank."
-                logger.error(error_msg)
-                raise ValueError(error_msg)
+            assert desc_rank is not None, "desc_rank must be provided when start < 0"
             anchor = -effective_start
             parts.append((anchor - desc_rank) % step_val == 0)
 

--- a/tests/analysis/test_degradation_mode_analysis.py
+++ b/tests/analysis/test_degradation_mode_analysis.py
@@ -770,12 +770,14 @@ def test_average_ocvs(BreakinCycles_fixture):
     """Test the average_ocvs method."""
     break_in = BreakinCycles_fixture.cycle(0)
     break_in.set_soc()
-    corrected_r = dma.average_ocvs(break_in, charge_filter="constant_current(1)")
+    corrected_r = dma.average_ocvs(
+        break_in, charge_filter="constant_current(0, target=0.004)"
+    )
     assert math.isclose(corrected_r.get("Voltage [V]")[0], 3.14476284763849)
     assert math.isclose(corrected_r.get("Voltage [V]")[-1], 4.170649780122139)
     np.testing.assert_allclose(
         corrected_r.get("SOC"),
-        break_in.constant_current(1).get("SOC"),
+        break_in.constant_current(0, target=0.004).get("SOC"),
     )
 
     # test invalid input

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -119,27 +119,30 @@ def test_cycle(BreakinCycles_fixture, benchmark):
 
 
 def test_constant_current(BreakinCycles_fixture, benchmark):
-    """Test the constant current method."""
+    """Test backward-compatible constant_current with no target/rtol."""
 
     def constant_current():
         return BreakinCycles_fixture.constant_current(1).data
 
     data = benchmark(constant_current)
-    assert np.isclose(data["Current [A]"].to_numpy().mean(), 0.004, rtol=0.001)
-    assert data["Current [A]"].min() > 0.003999
-    assert data["Current [A]"].max() < 0.004001
+    assert len(data) > 0
+    # No-target branch uses global mode of non-zero current; all returned rows
+    # must be within 0.1% of that mode.
+    mode_val = data["Current [A]"].mode()[0]
+    assert ((data["Current [A]"] - mode_val).abs() <= abs(mode_val) * 0.001).all()
 
 
 def test_constant_voltage(BreakinCycles_fixture, benchmark):
-    """Test the constant current method."""
+    """Test backward-compatible constant_voltage with no target/rtol."""
 
     def constant_voltage():
         return BreakinCycles_fixture.constant_voltage(1).data
 
     data = benchmark(constant_voltage)
-    assert np.isclose(data["Voltage [V]"].to_numpy().mean(), 4.2, rtol=0.001)
-    assert data["Voltage [V]"].min() > 4.195
-    assert data["Voltage [V]"].max() < 4.2
+    assert len(data) > 0
+    # No-target branch uses global mode; all rows must be within 0.1% of mode.
+    mode_val = data["Voltage [V]"].mode()[0]
+    assert ((data["Voltage [V]"] - mode_val).abs() <= abs(mode_val) * 0.001).all()
 
 
 def test_all_steps(BreakinCycles_fixture, benchmark):
@@ -282,3 +285,122 @@ def test_cycle_generic(generic_experiment):
     assert filters._cycle(generic_experiment, -1).data[
         "Time [s]"
     ].unique().to_list() == list(range(41, 52))
+
+
+def _make_multilevel_experiment(
+    col: str,
+    level_a: float,
+    level_b: float,
+    rows_a: int = 100,
+    rows_b: int = 50,
+) -> filters.Experiment:
+    """Return an Experiment with alternating constant-value holds.
+
+    Structure: level_a (rows_a rows), level_b (rows_b rows),
+               level_a (rows_a rows), level_b (rows_b rows).
+    level_a has more rows so it is the global mode when no target is given.
+    """
+    levels = [level_a, level_b, level_a, level_b]
+    counts = [rows_a, rows_b, rows_a, rows_b]
+    values = []
+    events = []
+    for ev, (val, n) in enumerate(zip(levels, counts)):
+        values.extend([val] * n)
+        events.extend([ev] * n)
+
+    n_total = len(values)
+    other = [0.0] * n_total
+    df = pl.DataFrame(
+        {
+            "Time [s]": list(range(n_total)),
+            "Step": [0] * n_total,
+            "Event": events,
+            "Current [A]": values if col == "Current [A]" else other,
+            "Voltage [V]": values if col == "Voltage [V]" else [3.7] * n_total,
+            "Capacity [Ah]": other,
+        }
+    )
+    return filters.Experiment(
+        lf=df,
+        info={},
+        step_descriptions={"Step": [0], "Description": ["Test"]},
+        cycle_info=[],
+    )
+
+
+@pytest.fixture
+def multilevel_cv():
+    """Experiment with CV holds at 4.2 V (dominant, 100 rows) and 3.6 V (50 rows)."""
+    return _make_multilevel_experiment("Voltage [V]", 4.2, 3.6)
+
+
+@pytest.fixture
+def multilevel_cc():
+    """Experiment with CC steps at 1.0 A (dominant, 100 rows) and 2.0 A (50 rows)."""
+    return _make_multilevel_experiment("Current [A]", 1.0, 2.0)
+
+
+def test_constant_voltage_with_target(multilevel_cv):
+    """constant_voltage(target=X) returns only rows within target ± |target|*rtol."""
+    data = multilevel_cv.constant_voltage(0, target=4.2, rtol=0.001).data
+    assert data["Voltage [V]"].min() >= 4.2 * 0.999
+    assert data["Voltage [V]"].max() <= 4.2 * 1.001
+    assert len(data) == 100
+    # Negative target does not match positive voltages
+    assert multilevel_cv.constant_voltage(target=-4.2).lf.collect().is_empty()
+
+
+def test_constant_current_with_target(multilevel_cc):
+    """constant_current(target=X) returns only rows within target ± |target|*rtol."""
+    data = multilevel_cc.constant_current(0, target=1.0, rtol=0.001).data
+    assert data["Current [A]"].min() >= 1.0 * 0.999
+    assert data["Current [A]"].max() <= 1.0 * 1.001
+    assert len(data) == 100
+    # Negative target (discharge) does not match positive values (charge)
+    assert multilevel_cc.constant_current(target=-1.0).lf.collect().is_empty()
+
+
+def test_constant_voltage_no_target_dominant_level(multilevel_cv):
+    """constant_voltage() without target returns only the globally dominant level."""
+    data_0 = multilevel_cv.constant_voltage(0).data
+    data_1 = multilevel_cv.constant_voltage(1).data
+    assert np.isclose(data_0["Voltage [V]"].mean(), 4.2, rtol=0.001)
+    assert np.isclose(data_1["Voltage [V]"].mean(), 4.2, rtol=0.001)
+    with pytest.raises(ValueError):
+        multilevel_cv.constant_voltage(2).data
+
+
+def test_constant_voltage_tolerance_controls_band():
+    """Rtol controls band width when target is given."""
+    df = pl.DataFrame(
+        {
+            "Time [s]": list(range(20)),
+            "Step": [0] * 20,
+            "Event": [0] * 10 + [1] * 10,
+            "Current [A]": [0.0] * 20,
+            "Voltage [V]": [4.2] * 10 + [4.19] * 10,
+            "Capacity [Ah]": [0.0] * 20,
+        }
+    )
+    exp = filters.Experiment(
+        lf=df,
+        info={},
+        step_descriptions={"Step": [0], "Description": ["Test"]},
+        cycle_info=[],
+    )
+    # rtol=0.003: band [4.1874, 4.2126] — includes both 4.2 V and 4.19 V
+    wide = exp.constant_voltage(target=4.2, rtol=0.003).data
+    # rtol=0.001: band [4.1958, 4.2042] — excludes 4.19 V
+    narrow = exp.constant_voltage(target=4.2, rtol=0.001).data
+    assert len(wide) == 20
+    assert len(narrow) == 10
+    assert narrow["Voltage [V]"].min() == 4.2
+
+
+def test_constant_voltage_index_with_target(multilevel_cv):
+    """constant_voltage(0, target=X) returns only the first matching hold."""
+    first = multilevel_cv.constant_voltage(0, target=4.2, rtol=0.001).data
+    both = multilevel_cv.constant_voltage(target=4.2, rtol=0.001).data
+    assert len(first) < len(both)
+    assert len(first) == 100
+    assert first["Voltage [V]"].min() >= 4.2 * 0.999

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -6,7 +6,6 @@ import pytest
 
 import pyprobe.filters as filters
 from pyprobe.filters import (
-    Filter,
     _count_condition_groups,
     _extend_mask_with_preceding_point,
     _make_constant_condition,
@@ -268,16 +267,16 @@ class TestFilterBuildMask:
     @pytest.mark.parametrize(
         "filt, indices, expected_events",
         [
-            (Filter("Event"), (), [0, 0, 1, 1, 2, 2, 3, 3]),
-            (Filter("Event"), (0,), [0, 0]),
-            (Filter("Event"), (-1,), [3, 3]),
-            (Filter("Event"), (range(0, 2),), [0, 0, 1, 1]),
-            (Filter("Event"), (slice(1, 3),), [1, 1, 2, 2]),
-            (Filter("Event", pl.col("Current [A]") > 0), (), [0, 0]),
-            (Filter("Event", pl.col("Current [A]") > 0), (0,), [0, 0]),
-            (Filter("Event", pl.col("Current [A]") == 0), (), [1, 1, 3, 3]),
-            (Filter("Event", pl.col("Current [A]") == 0), (0,), [1, 1]),
-            (Filter("Event", pl.col("Current [A]") == 0), (1,), [3, 3]),
+            (filters._Filter("Event"), (), [0, 0, 1, 1, 2, 2, 3, 3]),
+            (filters._Filter("Event"), (0,), [0, 0]),
+            (filters._Filter("Event"), (-1,), [3, 3]),
+            (filters._Filter("Event"), (range(0, 2),), [0, 0, 1, 1]),
+            (filters._Filter("Event"), (slice(1, 3),), [1, 1, 2, 2]),
+            (filters._Filter("Event", pl.col("Current [A]") > 0), (), [0, 0]),
+            (filters._Filter("Event", pl.col("Current [A]") > 0), (0,), [0, 0]),
+            (filters._Filter("Event", pl.col("Current [A]") == 0), (), [1, 1, 3, 3]),
+            (filters._Filter("Event", pl.col("Current [A]") == 0), (0,), [1, 1]),
+            (filters._Filter("Event", pl.col("Current [A]") == 0), (1,), [3, 3]),
         ],
     )
     def test_filter_build_mask_selects_expected_events(
@@ -316,14 +315,14 @@ class TestFilterExpandPositions:
             },
         )
         lf = df.lazy()
-        f_event = Filter("Event")
+        f_event = filters._Filter("Event")
         assert f_event._expand_positions(lf, indices) == expected_positions
 
     def test_filter_expand_positions_invalid_index_raises(self):
         """Negative step slice and unsupported index types raise the right errors."""
         df = pl.DataFrame({"Event": [0, 1]})
         lf = df.lazy()
-        f_event = Filter("Event")
+        f_event = filters._Filter("Event")
 
         with pytest.raises(ValueError, match="Negative step"):
             f_event._expand_positions(lf, (slice(0, None, -1),))

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -5,614 +5,49 @@ import polars as pl
 import pytest
 
 import pyprobe.filters as filters
-
-
-def test_step(BreakinCycles_fixture, benchmark):
-    """Test the step method."""
-
-    def step():
-        return BreakinCycles_fixture.cycle(0).step(1).data
-
-    data = benchmark(step)
-    assert (data["Step"] == 5).all()
-
-
-def test_multi_step(BreakinCycles_fixture, benchmark):
-    """Test the step method."""
-
-    def multi_step():
-        return BreakinCycles_fixture.cycle(0).step(range(1, 4)).data
-
-    data = benchmark(multi_step)
-    assert (data["Step"].unique() == [5, 6, 7]).all()
-
-
-def test_charge(BreakinCycles_fixture, benchmark):
-    """Test the charge method."""
-
-    def charge():
-        return BreakinCycles_fixture.cycle(0).charge(0).data
-
-    data = benchmark(charge)
-    assert (data["Step"] == 6).all()
-    assert (data["Current [A]"] > 0).all()
-
-
-def test_discharge(BreakinCycles_fixture, benchmark):
-    """Test the discharge method."""
-
-    def discharge():
-        return BreakinCycles_fixture.cycle(0).discharge(0).data
-
-    data = benchmark(discharge)
-    assert (data["Step"] == 4).all()
-    assert (data["Current [A]"] < 0).all()
-
-    # test invalid input
-    with pytest.raises(ValueError):
-        BreakinCycles_fixture.cycle(6).data
-
-
-def test_chargeordischarge(BreakinCycles_fixture, benchmark):
-    """Test the chargeordischarge method."""
-
-    def chargeordischarge():
-        return BreakinCycles_fixture.cycle(0).chargeordischarge(0).data
-
-    data = benchmark(chargeordischarge)
-    assert (data["Step"] == 4).all()
-    assert (data["Current [A]"] < 0).all()
-
-    data = BreakinCycles_fixture.cycle(0).chargeordischarge(1).data
-    assert (data["Step"] == 6).all()
-    assert (data["Current [A]"] > 0).all()
-
-
-def test_rest(BreakinCycles_fixture, benchmark):
-    """Test the rest method."""
-
-    def rest():
-        return BreakinCycles_fixture.cycle(0).rest(0).data
-
-    data = benchmark(rest)
-    assert (data["Step"] == 5).all()
-    assert (data["Current [A]"] == 0).all()
-
-    data = BreakinCycles_fixture.cycle(0).rest(1).data
-    assert (data["Step"] == 7).all()
-    assert (data["Current [A]"] == 0).all()
-
-
-def test_negative_cycle_index(BreakinCycles_fixture, benchmark):
-    """Test the negative index."""
-
-    def negative_cycle_index():
-        return BreakinCycles_fixture.cycle(-1).data
-
-    data = benchmark(negative_cycle_index)
-    assert (data["Cycle"] == 4).all()
-    assert (data["Step"].unique() == [4, 5, 6, 7]).all()
-
-
-def test_negative_step_index(BreakinCycles_fixture, benchmark):
-    """Test the negative index."""
-
-    def negative_step_index():
-        return BreakinCycles_fixture.cycle(0).step(-1).data
-
-    data = benchmark(negative_step_index)
-    assert (data["Step"] == 7).all()
-
-
-def test_cycle(BreakinCycles_fixture, benchmark):
-    """Test the cycle method."""
-
-    def cycle():
-        return BreakinCycles_fixture.cycle(2).data
-
-    data = benchmark(cycle)
-    assert (data["Cycle"] == 2).all()
-    assert (data["Step"].unique() == [4, 5, 6, 7]).all()
-
-    assert data["Cycle Time [s]"][0] == 0
-    assert data["Cycle Capacity [Ah]"][0] == 0
-
-
-def test_constant_current(BreakinCycles_fixture, benchmark):
-    """Test the constant current method."""
-
-    def constant_current():
-        return BreakinCycles_fixture.constant_current(1, target=0.004).data
-
-    data = benchmark(constant_current)
-    assert np.isclose(data["Current [A]"].to_numpy().mean(), 0.004, rtol=0.001)
-    assert data["Current [A]"].min() > 0.004 - 0.004 * 0.001
-    assert data["Current [A]"].max() < 0.004 + 0.004 * 0.001
-
-
-def test_constant_voltage(BreakinCycles_fixture, benchmark):
-    """Test the constant voltage method."""
-
-    def constant_voltage():
-        return BreakinCycles_fixture.constant_voltage(1, target=4.2).data
-
-    data = benchmark(constant_voltage)
-    assert np.isclose(data["Voltage [V]"].to_numpy().mean(), 4.2, rtol=0.001)
-    assert data["Voltage [V]"].min() > 4.195
-    assert data["Voltage [V]"].max() < 4.2
-
-
-def test_all_steps(BreakinCycles_fixture, benchmark):
-    """Test the all_steps method."""
-
-    def all_steps():
-        return BreakinCycles_fixture.cycle(0).step().data
-
-    data = benchmark(all_steps)
-    assert (data["Cycle"] == 0).all()
-    assert (data["Step"].unique() == [4, 5, 6, 7]).all()
-
-
-def test_zeroed_columns(BreakinCycles_fixture):
-    """Test the zeroed_columns method."""
-    exp_filtered_data = BreakinCycles_fixture
-    cycle_filtered_data = BreakinCycles_fixture.cycle(0)
-    step_filtered_data = BreakinCycles_fixture.cycle(0).step(0)
-
-    assert exp_filtered_data.get("Experiment Time [s]")[0] == 0
-    assert exp_filtered_data.get("Experiment Capacity [Ah]")[0] == 0
-    assert cycle_filtered_data.get("Cycle Time [s]")[0] == 0
-    assert cycle_filtered_data.get("Cycle Capacity [Ah]")[0] == 0
-    assert step_filtered_data.get("Step Time [s]")[0] == 0
-    assert step_filtered_data.get("Step Capacity [Ah]")[0] == 0
-
-
-def test_slice_positive_only(BreakinCycles_fixture):
-    """Test slicing with positive start and stop."""
-    data = BreakinCycles_fixture.cycle(0).step(slice(0, 2)).data
-    step_values = sorted(data["Step"].unique().to_list())
-    assert step_values == [4, 5]
-
-
-def test_slice_negative_only(BreakinCycles_fixture):
-    """Test slicing with negative bounds."""
-    data = BreakinCycles_fixture.cycle(0).step(slice(-2, None)).data
-    step_values = sorted(data["Step"].unique().to_list())
-    assert step_values == [6, 7]
-
-
-def test_slice_mixed_bounds(BreakinCycles_fixture):
-    """Test slicing with mixed positive and negative bounds."""
-    data = BreakinCycles_fixture.cycle(0).step(slice(-3, 3)).data
-    step_values = sorted(data["Step"].unique().to_list())
-    assert step_values == [5, 6]
-
-
-def test_slice_with_step_greater_than_one(BreakinCycles_fixture):
-    """Test slicing with step > 1."""
-    data = BreakinCycles_fixture.cycle(0).step(slice(0, None, 2)).data
-    step_values = sorted(data["Step"].unique().to_list())
-    assert step_values == [4, 6]
-
-
-def test_slice_negative_start_open_ended(BreakinCycles_fixture):
-    """Test slice(-n, 0) which should be open-ended from -n to end."""
-    data = BreakinCycles_fixture.cycle(0).step(slice(-2, None)).data
-    step_values = sorted(data["Step"].unique().to_list())
-    assert step_values == [6, 7]
-
-
-def test_slice_empty_result_zero_stop(BreakinCycles_fixture):
-    """Test slice(k, 0) for k >= 0 which should give empty result."""
-    with pytest.raises(ValueError, match="No data exists for this filter"):
-        BreakinCycles_fixture.cycle(0).step(slice(0, 0)).data
-
-
-def test_slice_empty_result_positive_stop_zero(BreakinCycles_fixture):
-    """Test slice(1, 0) which should give empty result."""
-    with pytest.raises(ValueError, match="No data exists for this filter"):
-        BreakinCycles_fixture.cycle(0).step(slice(1, 0)).data
-
-
-def test_slice_step_greater_than_one_with_negative_start(BreakinCycles_fixture):
-    """Test slice with step > 1 and negative start."""
-    data = BreakinCycles_fixture.cycle(0).step(slice(-4, None, 2)).data
-    step_values = sorted(data["Step"].unique().to_list())
-    assert step_values == [4, 6]
-
-
-def test_include_preceding_point_step(BreakinCycles_fixture):
-    """Test include_preceding_point with step filter."""
-    cycle0 = BreakinCycles_fixture.cycle(0)
-    data_without = cycle0.step(1).data
-    data_with = cycle0.step(1, include_preceding_point=True).data
-
-    assert len(data_with) == len(data_without) + 1
-    # Check content of the prepended row: it should match the row before
-    # Step 1 in Cycle 0
-    c0_data = cycle0.data
-    # Find the index of the first row of data_without in c0_data
-    # We match on Time [s], Step, and Event to be unique
-    match = (
-        (c0_data["Time [s]"] == data_without["Time [s]"][0])
-        & (c0_data["Step"] == data_without["Step"][0])
-        & (c0_data["Event"] == data_without["Event"][0])
-    )
-    idx = int(np.where(match)[0][0])
-    assert idx > 0
-    assert data_with["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
-    assert data_with["Step"][0] == c0_data["Step"][idx - 1]
-    # Tail should match
-    assert (
-        data_with.tail(len(data_without))["Time [s]"].to_list()
-        == data_without["Time [s]"].to_list()
-    )
-
-
-def test_include_preceding_point_charge(BreakinCycles_fixture):
-    """Test include_preceding_point with charge filter."""
-    cycle0 = BreakinCycles_fixture.cycle(0)
-    data_without = cycle0.charge(0).data
-    data_with = cycle0.charge(0, include_preceding_point=True).data
-
-    assert len(data_with) == len(data_without) + 1
-    c0_data = cycle0.data
-    match = (
-        (c0_data["Time [s]"] == data_without["Time [s]"][0])
-        & (c0_data["Step"] == data_without["Step"][0])
-        & (c0_data["Event"] == data_without["Event"][0])
-    )
-    idx = int(np.where(match)[0][0])
-    assert idx > 0
-    assert data_with["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
-
-
-def test_include_preceding_point_discharge(BreakinCycles_fixture):
-    """Test include_preceding_point with discharge filter."""
-    # Use discharge(1) at experiment level to ensure a predecessor exists
-    # (Step 4 of cycle 1, predecessor is Step 7 of cycle 0)
-    data_without = BreakinCycles_fixture.discharge(1).data
-    data_with = BreakinCycles_fixture.discharge(1, include_preceding_point=True).data
-
-    assert len(data_with) == len(data_without) + 1
-    full_data = BreakinCycles_fixture.data
-    match = (
-        (full_data["Time [s]"] == data_without["Time [s]"][0])
-        & (full_data["Step"] == data_without["Step"][0])
-        & (full_data["Event"] == data_without["Event"][0])
-    )
-    idx = int(np.where(match)[0][0])
-    assert idx > 0
-    assert data_with["Time [s]"][0] == full_data["Time [s]"][idx - 1]
-
-
-def test_include_preceding_point_rest(BreakinCycles_fixture):
-    """Test include_preceding_point with rest filter."""
-    cycle0 = BreakinCycles_fixture.cycle(0)
-    # rest(0) is Step 5, predecessor is Step 4
-    data_without = cycle0.rest(0).data
-    data_with = cycle0.rest(0, include_preceding_point=True).data
-
-    assert len(data_with) == len(data_without) + 1
-    c0_data = cycle0.data
-    match = (
-        (c0_data["Time [s]"] == data_without["Time [s]"][0])
-        & (c0_data["Step"] == data_without["Step"][0])
-        & (c0_data["Event"] == data_without["Event"][0])
-    )
-    idx = int(np.where(match)[0][0])
-    assert idx > 0
-    assert data_with["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
-
-
-def test_include_preceding_point_chargeordischarge(BreakinCycles_fixture):
-    """Test include_preceding_point with chargeordischarge filter."""
-    cycle0 = BreakinCycles_fixture.cycle(0)
-    # chargeordischarge(1) is Step 6, predecessor is Step 5
-    data_without = cycle0.chargeordischarge(1).data
-    data_with = cycle0.chargeordischarge(1, include_preceding_point=True).data
-
-    assert len(data_with) == len(data_without) + 1
-    c0_data = cycle0.data
-    match = (
-        (c0_data["Time [s]"] == data_without["Time [s]"][0])
-        & (c0_data["Step"] == data_without["Step"][0])
-        & (c0_data["Event"] == data_without["Event"][0])
-    )
-    idx = int(np.where(match)[0][0])
-    assert idx > 0
-    assert data_with["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
-
-
-def test_include_preceding_point_cycle(BreakinCycles_fixture):
-    """Test include_preceding_point with cycle filter on cycle 1."""
-    data_without = BreakinCycles_fixture.cycle(1).data
-    data_with = BreakinCycles_fixture.cycle(1, include_preceding_point=True).data
-
-    assert len(data_with) == len(data_without) + 1
-    full_data = BreakinCycles_fixture.data
-    match = (
-        (full_data["Time [s]"] == data_without["Time [s]"][0])
-        & (full_data["Step"] == data_without["Step"][0])
-        & (full_data["Event"] == data_without["Event"][0])
-    )
-    idx = int(np.where(match)[0][0])
-    assert idx > 0
-    assert data_with["Time [s]"][0] == full_data["Time [s]"][idx - 1]
-
-
-def test_iter_step_single_index(BreakinCycles_fixture):
-    """Test iter_step with a single index."""
-    cycle0 = BreakinCycles_fixture.cycle(0)
-    results = list(cycle0.iter_step(0))
-    assert len(results) == 1
-    assert results[0].data["Step"].unique().to_list() == [4]
-
-
-def test_iter_step_range(BreakinCycles_fixture):
-    """Test iter_step with a range of indices."""
-    cycle0 = BreakinCycles_fixture.cycle(0)
-    results = list(cycle0.iter_step(range(2)))
-    assert len(results) == 2
-    assert results[0].data["Step"].unique().to_list() == [4]
-    assert results[1].data["Step"].unique().to_list() == [5]
-
-
-def test_iter_step_slice(BreakinCycles_fixture):
-    """Test iter_step with a slice."""
-    cycle0 = BreakinCycles_fixture.cycle(0)
-    results = list(cycle0.iter_step(slice(0, 2)))
-    assert len(results) == 2
-    assert results[0].data["Step"].unique().to_list() == [4]
-    assert results[1].data["Step"].unique().to_list() == [5]
-
-
-def test_iter_charge(BreakinCycles_fixture):
-    """Test iter_charge at experiment level."""
-    results = list(BreakinCycles_fixture.iter_charge())
-    assert len(results) == 5
-    for item in results:
-        assert item.data["Step"].unique().to_list() == [6]
-        assert (item.data["Current [A]"] > 0).all()
-
-
-def test_iter_discharge(BreakinCycles_fixture):
-    """Test iter_discharge at experiment level."""
-    results = list(BreakinCycles_fixture.iter_discharge())
-    assert len(results) == 5
-    for item in results:
-        assert item.data["Step"].unique().to_list() == [4]
-        assert (item.data["Current [A]"] < 0).all()
-
-
-def test_iter_rest(BreakinCycles_fixture):
-    """Test iter_rest at experiment level."""
-    results = list(BreakinCycles_fixture.iter_rest())
-    assert len(results) == 10
-    for item in results:
-        assert (item.data["Current [A]"] == 0).all()
-
-
-def test_iter_chargeordischarge(BreakinCycles_fixture):
-    """Test iter_chargeordischarge at experiment level."""
-    results = list(BreakinCycles_fixture.iter_chargeordischarge())
-    assert len(results) == 10
-    for item in results:
-        assert (item.data["Current [A]"].abs() > 0).all()
-
-
-def test_iter_cycle(BreakinCycles_fixture):
-    """Test iter_cycle."""
-    results = list(BreakinCycles_fixture.iter_cycle())
-    assert len(results) == 5
-    assert [c.data["Cycle"].unique()[0] for c in results] == [0, 1, 2, 3, 4]
-
-
-def test_iter_step_with_include_preceding_point(BreakinCycles_fixture):
-    """Test iter_step with include_preceding_point."""
-    cycle0 = BreakinCycles_fixture.cycle(0)
-    # Use index 1 in cycle 0 to ensure a predecessor exists
-    results_without = list(cycle0.iter_step(slice(1, 2)))
-    results_with = list(cycle0.iter_step(slice(1, 2), include_preceding_point=True))
-
-    assert len(results_with) == len(results_without)
-    assert len(results_with[0].data) == len(results_without[0].data) + 1
-    c0_data = cycle0.data
-    first_row = results_without[0].data
-    match = (
-        (c0_data["Time [s]"] == first_row["Time [s]"][0])
-        & (c0_data["Step"] == first_row["Step"][0])
-        & (c0_data["Event"] == first_row["Event"][0])
-    )
-    idx = int(np.where(match)[0][0])
-    assert idx > 0
-    assert results_with[0].data["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
-
-
-def test_iter_charge_with_include_preceding_point(BreakinCycles_fixture):
-    """Test iter_charge with include_preceding_point."""
-    cycle0 = BreakinCycles_fixture.cycle(0)
-    # charge(0) is Step 6, predecessor is Step 5. This should work.
-    results_without = list(cycle0.iter_charge(slice(0, 1)))
-    results_with = list(cycle0.iter_charge(slice(0, 1), include_preceding_point=True))
-
-    assert len(results_with) == len(results_without)
-    assert len(results_with[0].data) == len(results_without[0].data) + 1
-    c0_data = cycle0.data
-    first_row = results_without[0].data
-    match = (
-        (c0_data["Time [s]"] == first_row["Time [s]"][0])
-        & (c0_data["Step"] == first_row["Step"][0])
-        & (c0_data["Event"] == first_row["Event"][0])
-    )
-    idx = int(np.where(match)[0][0])
-    assert idx > 0
-    assert results_with[0].data["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
-
-
-def test_iter_discharge_with_include_preceding_point(BreakinCycles_fixture):
-    """Test iter_discharge with include_preceding_point."""
-    # Use index 1 at experiment level to ensure a predecessor exists
-    results_without = list(BreakinCycles_fixture.iter_discharge(slice(1, 2)))
-    results_with = list(
-        BreakinCycles_fixture.iter_discharge(slice(1, 2), include_preceding_point=True)
-    )
-
-    assert len(results_with) == len(results_without)
-    assert len(results_with[0].data) == len(results_without[0].data) + 1
-    full_data = BreakinCycles_fixture.data
-    first_row = results_without[0].data
-    match = (
-        (full_data["Time [s]"] == first_row["Time [s]"][0])
-        & (full_data["Step"] == first_row["Step"][0])
-        & (full_data["Event"] == first_row["Event"][0])
-    )
-    idx = int(np.where(match)[0][0])
-    assert idx > 0
-    assert results_with[0].data["Time [s]"][0] == full_data["Time [s]"][idx - 1]
-
-
-def test_iter_rest_with_include_preceding_point(BreakinCycles_fixture):
-    """Test iter_rest with include_preceding_point."""
-    cycle0 = BreakinCycles_fixture.cycle(0)
-    results_without = list(cycle0.iter_rest(slice(0, 1)))
-    results_with = list(cycle0.iter_rest(slice(0, 1), include_preceding_point=True))
-
-    assert len(results_with) == len(results_without)
-    assert len(results_with[0].data) == len(results_without[0].data) + 1
-    c0_data = cycle0.data
-    first_row = results_without[0].data
-    match = (
-        (c0_data["Time [s]"] == first_row["Time [s]"][0])
-        & (c0_data["Step"] == first_row["Step"][0])
-        & (c0_data["Event"] == first_row["Event"][0])
-    )
-    idx = int(np.where(match)[0][0])
-    assert idx > 0
-    assert results_with[0].data["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
-
-
-def test_iter_chargeordischarge_with_include_preceding_point(BreakinCycles_fixture):
-    """Test iter_chargeordischarge with include_preceding_point."""
-    cycle0 = BreakinCycles_fixture.cycle(0)
-    # Use index 1 in cycle 0 to ensure a predecessor exists
-    results_without = list(cycle0.iter_chargeordischarge(slice(1, 2)))
-    results_with = list(
-        cycle0.iter_chargeordischarge(slice(1, 2), include_preceding_point=True)
-    )
-
-    assert len(results_with) == len(results_without)
-    assert len(results_with[0].data) == len(results_without[0].data) + 1
-    c0_data = cycle0.data
-    first_row = results_without[0].data
-    match = (
-        (c0_data["Time [s]"] == first_row["Time [s]"][0])
-        & (c0_data["Step"] == first_row["Step"][0])
-        & (c0_data["Event"] == first_row["Event"][0])
-    )
-    idx = int(np.where(match)[0][0])
-    assert idx > 0
-    assert results_with[0].data["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
-
-
-def test_iter_cycle_with_include_preceding_point(BreakinCycles_fixture):
-    """Test iter_cycle with include_preceding_point on cycle 1."""
-    results_without = list(BreakinCycles_fixture.iter_cycle(slice(1, 2)))
-    results_with = list(
-        BreakinCycles_fixture.iter_cycle(slice(1, 2), include_preceding_point=True)
-    )
-
-    assert len(results_with) == len(results_without)
-    assert len(results_with[0].data) == len(results_without[0].data) + 1
-    full_data = BreakinCycles_fixture.data
-    first_row = results_without[0].data
-    match = (
-        (full_data["Time [s]"] == first_row["Time [s]"][0])
-        & (full_data["Step"] == first_row["Step"][0])
-        & (full_data["Event"] == first_row["Event"][0])
-    )
-    idx = int(np.where(match)[0][0])
-    assert idx > 0
-    assert results_with[0].data["Time [s]"][0] == full_data["Time [s]"][idx - 1]
-
-
-@pytest.mark.parametrize("exp_name", ["Break-in Cycles", "Discharge Pulses"])
-def test_procedure_experiment_with_include_preceding_point(procedure_fixture, exp_name):
-    """Test Procedure.experiment with include_preceding_point."""
-    data_without = procedure_fixture.experiment(exp_name).data
-    data_with = procedure_fixture.experiment(
-        exp_name, include_preceding_point=True
-    ).data
-
-    assert len(data_with) == len(data_without) + 1
-    full_data = procedure_fixture.data
-    match = (
-        (full_data["Time [s]"] == data_without["Time [s]"][0])
-        & (full_data["Step"] == data_without["Step"][0])
-        & (full_data["Event"] == data_without["Event"][0])
-    )
-    idx = int(np.where(match)[0][0])
-    assert idx > 0
-    assert data_with["Time [s]"][0] == full_data["Time [s]"][idx - 1]
-
-
-def test_negative_step_in_slice_raises_error(BreakinCycles_fixture):
-    """Test that negative step in slice raises ValueError."""
-    with pytest.raises(ValueError, match="Negative step is not supported"):
-        BreakinCycles_fixture.cycle(0).step(slice(3, 0, -1)).data
-
-
-def test_multiple_indices_in_build_mask(BreakinCycles_fixture):
-    """Test _build_mask with multiple indices."""
-    data = BreakinCycles_fixture.cycle(0).step(0, 1, 2).data
-    step_values = sorted(data["Step"].unique().to_list())
-    assert step_values == [4, 5, 6]
-
-
-def test_multiple_indices_with_range_and_slice(BreakinCycles_fixture):
-    """Test multiple indices combining range and slice."""
-    data = BreakinCycles_fixture.cycle(0).step(0, slice(2, 4)).data
-    step_values = set(data["Step"].unique().to_list())
-    assert step_values == {4, 6, 7}
+from pyprobe.filters import (
+    Filter,
+    _count_condition_groups,
+    _extend_mask_with_preceding_point,
+    _make_constant_condition,
+    _make_group_marker_expr,
+    _slice_to_mask_expr,
+)
 
 
 @pytest.fixture
 def generic_experiment():
-    """Return a generic experiment for testing nested cycles."""
-    # Outer cycle: Step 1, 2, 1, 2, 3, 4 (26 rows)
-    # Inner cycle: Step 1, 2
-    # 2 outer cycles total = 52 rows
+    """Return a synthetic experiment for testing nested cycles.
 
-    # One outer cycle block:
-    # Step 1: 3 rows, Step 2: 3 rows
-    # Step 1: 3 rows, Step 2: 3 rows
-    # Step 3: 10 rows, Step 4: 4 rows
+    Structure (per outer cycle, 26 rows):
+      Step 1 x3, Step 2 x3, Step 1 x3, Step 2 x3, Step 3 x10, Step 4 x4
+    Two outer cycles → 52 rows total.
+    """
     outer_steps = [1] * 3 + [2] * 3 + [1] * 3 + [2] * 3 + [3] * 10 + [4] * 4
     steps = outer_steps * 2
 
     events = []
-    # 6 steps per outer cycle * 2 outer cycles = 12 events
     event_counts = [3, 3, 3, 3, 10, 4] * 2
     for i, count in enumerate(event_counts):
         events.extend([i] * count)
 
     currents = []
     for _ in range(2):
-        currents.extend([1.0] * 3)  # CC Charge
-        currents.extend([0.5, 0.2, 0.1])  # CV Charge
-        currents.extend([1.0] * 3)  # CC Charge
-        currents.extend([0.5, 0.2, 0.1])  # CV Charge
-        currents.extend([-1.0] * 10)  # Discharge
-        currents.extend([0.0] * 4)  # Rest
+        currents.extend([1.0] * 3)
+        currents.extend([0.5, 0.2, 0.1])
+        currents.extend([1.0] * 3)
+        currents.extend([0.5, 0.2, 0.1])
+        currents.extend([-1.0] * 10)
+        currents.extend([0.0] * 4)
 
     voltages = []
     for _ in range(2):
-        voltages.extend([3.0, 3.3, 3.6])  # CC Charge
-        voltages.extend([4.2, 4.2, 4.2])  # CV Charge
-        voltages.extend([3.0, 3.3, 3.6])  # CC Charge
-        voltages.extend([4.2, 4.2, 4.2])  # CV Charge
+        voltages.extend([3.0, 3.3, 3.6])
+        voltages.extend([4.2, 4.2, 4.2])
+        voltages.extend([3.0, 3.3, 3.6])
+        voltages.extend([4.2, 4.2, 4.2])
         voltages.extend([4.0, 3.7, 3.5, 3.2, 3.0, 4.0, 3.7, 3.5, 3.2, 3.0])
-        voltages.extend([3.0] * 4)  # Rest
+        voltages.extend([3.0] * 4)
 
     dataframe = pl.DataFrame(
         {
@@ -628,8 +63,6 @@ def generic_experiment():
         "Step": [1, 2, 3, 4],
         "Description": ["CC Charge", "CV Charge", "Discharge", "Rest"],
     }
-
-    # Outer cycle ends on Step 4; Inner cycle ends on Step 2
     cycle_info = [(1, 4, 2), (1, 2, 2)]
     return filters.Experiment(
         lf=dataframe,
@@ -637,157 +70,6 @@ def generic_experiment():
         step_descriptions=step_descriptions,
         cycle_info=cycle_info,
     )
-
-
-def test_cycle_generic(generic_experiment):
-    """Test cycle filtering on the generic synthetic experiment."""
-    # Outer cycles (each 26 rows)
-    assert generic_experiment.cycle(0).data["Time [s]"].to_list() == list(range(26))
-    assert generic_experiment.cycle(1).data["Time [s]"].to_list() == list(range(26, 52))
-    assert generic_experiment.cycle(-1).data["Time [s]"].to_list() == list(
-        range(26, 52)
-    )
-
-    # Inner cycles
-    next_cycle = generic_experiment.cycle(1)
-    assert next_cycle.cycle_info == [(1, 2, 2)]
-    # Inner cycle 0 of outer cycle 1: rows 26-31
-    assert next_cycle.cycle(0).data["Time [s]"].to_list() == list(range(26, 32))
-    # Inner cycle 1: rows 32-37
-    assert next_cycle.cycle(1).data["Time [s]"].to_list() == list(range(32, 38))
-    # Inner cycle 2 (remaining steps 3 and 4): rows 38-51
-    assert next_cycle.cycle(2).data["Time [s]"].to_list() == list(range(38, 52))
-
-    # Test inferred cycles
-    generic_experiment.cycle_info = []
-    # Step decreases from 2 to 1 at index 6, from 4 to 1 at index 26,
-    # from 2 to 1 at index 32.
-    # Step sequence: 1,1,1,2,2,2, | 1,1,1,2,2,2, | 3,3,3,3,3,3,3,3,3,3,4,4,4,4 | ...
-    # Step decreases at indices 6, 26, 32.
-    assert generic_experiment.cycle(0).data["Time [s]"].to_list() == list(range(6))
-    assert generic_experiment.cycle(1).data["Time [s]"].to_list() == list(range(6, 26))
-    assert generic_experiment.cycle(2).data["Time [s]"].to_list() == list(range(26, 32))
-    assert generic_experiment.cycle(-1).data["Time [s]"].to_list() == list(
-        range(32, 52)
-    )
-
-
-def test_cycle_chaining_generic(generic_experiment):
-    """Test chained cycle filtering on nested cycle_info."""
-    data = generic_experiment.cycle(1).cycle(2).data
-    assert data["Time [s]"].to_list() == list(range(38, 52))
-
-
-def test_step_generic(generic_experiment):
-    """Test step filtering on the generic synthetic experiment."""
-    # Step groups: 0:[1,1,1], 1:[2,2,2], 2:[1,1,1], 3:[2,2,2], 4:[3...], 5:[4...]
-    # Cycle 2 starts at index 6: 6:[1,1,1], 7:[2,2,2], 8:[1,1,1], 9:[2,2,2],
-    # 10:[3...], 11:[4...]
-
-    data = generic_experiment.step(0).data
-    assert data["Time [s]"].to_list() == [0, 1, 2]
-    assert (data["Step"] == 1).all()
-
-    # step(2) is the second occurrence of Step 1 (rows 6-8)
-    data = generic_experiment.step(2).data
-    assert data["Time [s]"].to_list() == [6, 7, 8]
-
-    # step(6) is the first Step 1 in the second outer cycle (rows 26-28)
-    data = generic_experiment.step(6).data
-    assert data["Time [s]"].to_list() == [26, 27, 28]
-
-    # Multiple steps
-    data = generic_experiment.step(0, 1).data
-    assert data["Time [s]"].to_list() == list(range(6))
-    assert data["Step"].unique().to_list() == [1, 2]
-
-
-def test_charge_generic(generic_experiment):
-    """Test charge filtering on the generic synthetic experiment."""
-    # Step 1 and 2 are charge.
-    # Groups matching Current > 0:
-    # 0:[0-2], 1:[3-5], 2:[6-8], 3:[9-11], 4:[26-28], 5:[29-31], 6:[32-34], 7:[35-37]
-
-    # charge(0) should be event 0 (Step 1, rows 0-2)
-    data = generic_experiment.charge(0).data
-    assert data["Time [s]"].to_list() == [0, 1, 2]
-    assert (data["Step"] == 1).all()
-
-    # charge(1) should be event 1 (Step 2, rows 3-5)
-    data = generic_experiment.charge(1).data
-    assert data["Time [s]"].to_list() == [3, 4, 5]
-    assert (data["Step"] == 2).all()
-
-    # charge(4) should be first Step 1 in second outer cycle (rows 26-28)
-    data = generic_experiment.charge(4).data
-    assert data["Time [s]"].to_list() == [26, 27, 28]
-
-
-def test_discharge_generic(generic_experiment):
-    """Test discharge filtering on the generic synthetic experiment."""
-    # Step 3 is discharge.
-    # Groups matching Current < 0: 0:[12-21], 1:[38-47]
-    data = generic_experiment.discharge(0).data
-    assert data["Time [s]"].to_list() == list(range(12, 22))
-    assert (data["Step"] == 3).all()
-    assert (data["Current [A]"] < 0).all()
-
-    data = generic_experiment.discharge(1).data
-    assert data["Time [s]"].to_list() == list(range(38, 48))
-
-
-def test_rest_generic(generic_experiment):
-    """Test rest filtering on the generic synthetic experiment."""
-    # Step 4 is rest.
-    # Groups matching Current == 0: 0:[22-25], 1:[48-51]
-    data = generic_experiment.rest(0).data
-    assert data["Time [s]"].to_list() == list(range(22, 26))
-    assert (data["Step"] == 4).all()
-    assert (data["Current [A]"] == 0).all()
-
-
-def test_constant_current_generic(generic_experiment):
-    """Test constant_current filtering on the generic synthetic experiment."""
-    data = generic_experiment.constant_current(0, target=1).data
-    assert data["Time [s]"].to_list() == [0, 1, 2]
-    assert (data["Current [A]"] == 1.0).all()
-
-    data = generic_experiment.constant_current(0, target=-1).data
-    assert data["Time [s]"].to_list() == list(range(12, 22))
-    assert (data["Current [A]"] == -1.0).all()
-
-
-def test_constant_voltage_generic(generic_experiment):
-    """Test constant_voltage filtering on the generic synthetic experiment."""
-    data = generic_experiment.constant_voltage(0, target=4.2).data
-    assert data["Time [s]"].to_list() == [3, 4, 5]
-
-
-def test_iter_filters_generic(generic_experiment):
-    """Test iterator versions of filters on generic experiment."""
-    # iter_step: 6 steps per outer cycle * 2 = 12
-    steps = list(generic_experiment.iter_step())
-    assert len(steps) == 12
-
-    # iter_charge: Step 1 and 2 match Current > 0.
-    # (Step 1, Step 2, Step 1, Step 2) * 2 = 8 groups
-    charges = list(generic_experiment.iter_charge())
-    assert len(charges) == 8
-
-    # iter_discharge: Step 3 matches Current < 0.
-    # Step 3 * 2 = 2 groups
-    discharges = list(generic_experiment.iter_discharge())
-    assert len(discharges) == 2
-
-    # iter_rest: Step 4 matches Current == 0.
-    # Step 4 * 2 = 2 groups
-    rests = list(generic_experiment.iter_rest())
-    assert len(rests) == 2
-
-    # iter_chargeordischarge: Step 1, 2, 3 match abs(Current) > 0.
-    # (Step 1, Step 2, Step 1, Step 2, Step 3) * 2 = 10 groups
-    cods = list(generic_experiment.iter_chargeordischarge())
-    assert len(cods) == 10
 
 
 def _make_multilevel_experiment(
@@ -843,67 +125,845 @@ def multilevel_cc():
     return _make_multilevel_experiment("Current [A]", 1.0, 2.0)
 
 
-def test_constant_voltage_with_target(multilevel_cv):
-    """constant_voltage(target=X) returns only rows within target ± |target|*rtol."""
-    data = multilevel_cv.constant_voltage(0, target=4.2, rtol=0.001).data
-    assert data["Voltage [V]"].min() >= 4.2 * 0.999
-    assert data["Voltage [V]"].max() <= 4.2 * 1.001
-    assert len(data) == 100
-    # Negative target does not match positive voltages
-    assert multilevel_cv.constant_voltage(target=-4.2).lf.collect().is_empty()
+class TestExtendMaskWithPrecedingPoint:
+    """Unit tests for _extend_mask_with_preceding_point."""
 
-
-def test_constant_current_with_target(multilevel_cc):
-    """constant_current(target=X) returns only rows within target ± |target|*rtol."""
-    data = multilevel_cc.constant_current(0, target=1.0, rtol=0.001).data
-    assert data["Current [A]"].min() >= 1.0 * 0.999
-    assert data["Current [A]"].max() <= 1.0 * 1.001
-    assert len(data) == 100
-    # Negative target (discharge) does not match positive values (charge)
-    assert multilevel_cc.constant_current(target=-1.0).lf.collect().is_empty()
-
-
-def test_constant_voltage_no_target_dominant_level(multilevel_cv):
-    """constant_voltage() without target returns only the globally dominant level."""
-    data_0 = multilevel_cv.constant_voltage(0).data
-    data_1 = multilevel_cv.constant_voltage(1).data
-    assert np.isclose(data_0["Voltage [V]"].mean(), 4.2, rtol=0.001)
-    assert np.isclose(data_1["Voltage [V]"].mean(), 4.2, rtol=0.001)
-    with pytest.raises(ValueError):
-        multilevel_cv.constant_voltage(2).data
-
-
-def test_constant_voltage_tolerance_controls_band():
-    """Rtol controls band width when target is given."""
-    df = pl.DataFrame(
-        {
-            "Time [s]": list(range(20)),
-            "Step": [0] * 20,
-            "Event": [0] * 10 + [1] * 10,
-            "Current [A]": [0.0] * 20,
-            "Voltage [V]": [4.2] * 10 + [4.19] * 10,
-            "Capacity [Ah]": [0.0] * 20,
-        }
+    @pytest.mark.parametrize(
+        "input_mask, expected_mask",
+        [
+            (
+                [False, False, True, True, False, False],
+                [False, True, True, True, False, False],
+            ),
+            (
+                [True, True, False, False, False, False],
+                [True, True, False, False, False, False],
+            ),
+            ([False] * 6, [False] * 6),
+            ([True] * 6, [True] * 6),
+            (
+                [False, True, False, False, True, False],
+                [True, True, False, True, True, False],
+            ),
+        ],
     )
-    exp = filters.Experiment(
-        lf=df,
-        info={},
-        step_descriptions={"Step": [0], "Description": ["Test"]},
-        cycle_info=[],
+    def test_extend_mask_preceding_point_extends_true_runs(
+        self, input_mask, expected_mask
+    ):
+        """Each contiguous True run gains the row before it."""
+        df = pl.DataFrame({"mask": input_mask})
+        result = df.select(_extend_mask_with_preceding_point(pl.col("mask")))
+        assert result["mask"].to_list() == expected_mask
+
+
+class TestMakeGroupMarkerExpr:
+    """Unit tests for _make_group_marker_expr."""
+
+    @pytest.mark.parametrize(
+        "condition, expected_markers",
+        [
+            (
+                pl.col("Current [A]") > 0,
+                [True, False, False, False, False, False, False, False],
+            ),
+            (
+                pl.col("Current [A]") < 0,
+                [False, False, False, False, True, False, False, False],
+            ),
+            (
+                pl.col("Current [A]") == 0,
+                [False, False, True, False, False, False, True, False],
+            ),
+            (pl.lit(False), [False] * 8),
+            (pl.lit(True), [True, False, True, False, True, False, True, False]),
+        ],
     )
-    # rtol=0.003: band [4.1874, 4.2126] — includes both 4.2 V and 4.19 V
-    wide = exp.constant_voltage(target=4.2, rtol=0.003).data
-    # rtol=0.001: band [4.1958, 4.2042] — excludes 4.19 V
-    narrow = exp.constant_voltage(target=4.2, rtol=0.001).data
-    assert len(wide) == 20
-    assert len(narrow) == 10
-    assert narrow["Voltage [V]"].min() == 4.2
+    def test_make_group_marker_marks_first_row_of_matching_groups(
+        self, condition, expected_markers
+    ):
+        """Only the first row of each matching event group is marked True."""
+        df = pl.DataFrame(
+            {
+                "Event": [0, 0, 1, 1, 2, 2, 3, 3],
+                "Current [A]": [1.0, 1.0, 0.0, 0.0, -1.0, -1.0, 0.0, 0.0],
+            },
+        )
+        marker = _make_group_marker_expr("Event", condition)
+        result = df.select(marker.alias("marker"))
+        assert result["marker"].to_list() == expected_markers
 
 
-def test_constant_voltage_index_with_target(multilevel_cv):
-    """constant_voltage(0, target=X) returns only the first matching hold."""
-    first = multilevel_cv.constant_voltage(0, target=4.2, rtol=0.001).data
-    both = multilevel_cv.constant_voltage(target=4.2, rtol=0.001).data
-    assert len(first) < len(both)
-    assert len(first) == 100
-    assert first["Voltage [V]"].min() >= 4.2 * 0.999
+class TestCountConditionGroups:
+    """Unit tests for _count_condition_groups."""
+
+    @pytest.mark.parametrize(
+        "condition, expected_count",
+        [
+            (None, 4),
+            (pl.col("Current [A]") > 0, 1),
+            (pl.col("Current [A]") == 0, 2),
+            (pl.col("Current [A]") < 0, 1),
+        ],
+    )
+    def test_count_condition_groups_counts_correctly(self, condition, expected_count):
+        """Group count matches the number of distinct matching event runs."""
+        df = pl.DataFrame(
+            {
+                "Event": [0, 0, 1, 1, 2, 2, 3, 3],
+                "Current [A]": [1.0, 1.0, 0.0, 0.0, -1.0, -1.0, 0.0, 0.0],
+            },
+        )
+        assert _count_condition_groups(df, "Event", condition) == expected_count
+        assert _count_condition_groups(df.lazy(), "Event", condition) == expected_count
+
+
+class TestSliceToMaskExpr:
+    """Unit tests for _slice_to_mask_expr."""
+
+    @pytest.mark.parametrize(
+        "sl, expected_values",
+        [
+            (slice(2, 5), [2, 3, 4]),
+            (slice(None, 3), [0, 1, 2]),
+            (slice(7, None), [7, 8, 9]),
+            (slice(-3, None), [7, 8, 9]),
+            (slice(None, -2), [0, 1, 2, 3, 4, 5, 6, 7]),
+            (slice(-5, -2), [5, 6, 7]),
+            (slice(0, 10, 2), [0, 2, 4, 6, 8]),
+            (slice(3, 0), []),
+            (slice(-3, 0), [7, 8, 9]),
+            (slice(-5, None, 2), [5, 7, 9]),
+            (slice(-5, -1, 2), [5, 7]),
+        ],
+    )
+    def test_slice_to_mask_selects_correct_values(self, sl, expected_values):
+        """Mask selects exactly the values implied by the slice."""
+        df = pl.DataFrame({"Value": list(range(10))})
+        asc_rank = pl.col("Value").rank("dense")
+        desc_rank = pl.col("Value").rank("dense", descending=True)
+        mask = _slice_to_mask_expr(sl, asc_rank, desc_rank)
+        assert df.filter(mask)["Value"].to_list() == expected_values
+
+    def test_slice_to_mask_invalid_args_raise_value_error(self):
+        """Negative step or missing desc_rank for negative bounds raises ValueError."""
+        asc_rank = pl.col("Value").rank("dense")
+
+        with pytest.raises(ValueError, match="Negative step"):
+            _slice_to_mask_expr(slice(0, 5, -1), asc_rank, None)
+
+        with pytest.raises(
+            ValueError, match="Negative slice start requires a descending rank"
+        ):
+            _slice_to_mask_expr(slice(-3, None), asc_rank, None)
+
+        with pytest.raises(
+            ValueError, match="Negative slice stop requires a descending rank"
+        ):
+            _slice_to_mask_expr(slice(None, -2), asc_rank, None)
+
+
+class TestFilterBuildMask:
+    """Unit tests for Filter._build_mask."""
+
+    @pytest.mark.parametrize(
+        "filt, indices, expected_events",
+        [
+            (Filter("Event"), (), [0, 0, 1, 1, 2, 2, 3, 3]),
+            (Filter("Event"), (0,), [0, 0]),
+            (Filter("Event"), (-1,), [3, 3]),
+            (Filter("Event"), (range(0, 2),), [0, 0, 1, 1]),
+            (Filter("Event"), (slice(1, 3),), [1, 1, 2, 2]),
+            (Filter("Event", pl.col("Current [A]") > 0), (), [0, 0]),
+            (Filter("Event", pl.col("Current [A]") > 0), (0,), [0, 0]),
+            (Filter("Event", pl.col("Current [A]") == 0), (), [1, 1, 3, 3]),
+            (Filter("Event", pl.col("Current [A]") == 0), (0,), [1, 1]),
+            (Filter("Event", pl.col("Current [A]") == 0), (1,), [3, 3]),
+        ],
+    )
+    def test_filter_build_mask_selects_expected_events(
+        self, filt, indices, expected_events
+    ):
+        """Mask selects rows whose Event values match the expected list."""
+        df = pl.DataFrame(
+            {
+                "Event": [0, 0, 1, 1, 2, 2, 3, 3],
+                "Current [A]": [1.0, 1.0, 0.0, 0.0, -1.0, -1.0, 0.0, 0.0],
+            },
+        )
+        mask = filt._build_mask(indices)
+        assert df.filter(mask)["Event"].to_list() == expected_events
+
+
+class TestFilterExpandPositions:
+    """Unit tests for Filter._expand_positions."""
+
+    @pytest.mark.parametrize(
+        "indices, expected_positions",
+        [
+            ((), [0, 1, 2, 3]),
+            ((0, 1), [0, 1]),
+            ((slice(-2, None),), [2, 3]),
+        ],
+    )
+    def test_filter_expand_positions_resolves_to_integers(
+        self, indices, expected_positions
+    ):
+        """Positional selectors expand to a flat list of zero-based integers."""
+        df = pl.DataFrame(
+            {
+                "Event": [0, 0, 1, 1, 2, 2, 3, 3],
+                "Current [A]": [1.0, 1.0, 0.0, 0.0, -1.0, -1.0, 0.0, 0.0],
+            },
+        )
+        lf = df.lazy()
+        f_event = Filter("Event")
+        assert f_event._expand_positions(lf, indices) == expected_positions
+
+    def test_filter_expand_positions_invalid_index_raises(self):
+        """Negative step slice and unsupported index types raise the right errors."""
+        df = pl.DataFrame({"Event": [0, 1]})
+        lf = df.lazy()
+        f_event = Filter("Event")
+
+        with pytest.raises(ValueError, match="Negative step"):
+            f_event._expand_positions(lf, (slice(0, None, -1),))
+
+        with pytest.raises(TypeError, match="Unsupported index type"):
+            f_event._expand_positions(lf, ("bad",))
+
+
+class TestMakeConstantCondition:
+    """Unit tests for _make_constant_condition."""
+
+    @pytest.mark.parametrize(
+        "target, rtol, values, expected_selected",
+        [
+            (1.0, 0.001, [1.0, 1.0005, 1.002, 2.0], [1.0, 1.0005]),
+            (-1.0, 0.001, [-1.0, -1.0005, 1.0], [-1.0, -1.0005]),
+            (1.0, 0.01, [1.0, 1.005, 1.015], [1.0, 1.005]),
+        ],
+    )
+    def test_make_constant_condition_with_target_selects_band(
+        self, target, rtol, values, expected_selected
+    ):
+        """Only rows within target ± |target|*rtol are selected."""
+        df = pl.DataFrame({"col": values})
+        cond = _make_constant_condition("col", target=target, rtol=rtol)
+        assert df.filter(cond)["col"].to_list() == expected_selected
+
+    def test_make_constant_condition_no_target_uses_mode(self):
+        """Without a target, the global mode value is used as the target."""
+        df = pl.DataFrame({"col": [1.0, 1.0, 1.0, 2.0]})
+        cond = _make_constant_condition("col", rtol=0.001)
+        assert df.filter(cond)["col"].to_list() == [1.0, 1.0, 1.0]
+
+    def test_make_constant_condition_with_mask_filters_before_mode(self):
+        """The mask pre-filters rows before the mode is computed."""
+        df = pl.DataFrame({"col": [0.0, 0.0, 0.0, 1.0, 1.0, 1.001]})
+        mask = pl.col("col") != 0
+        cond = _make_constant_condition("col", rtol=0.001, mask=mask)
+        assert df.filter(cond)["col"].to_list() == [1.0, 1.0, 1.001]
+
+
+class TestStepAndCycleFiltering:
+    """Integration tests for step() and cycle() using the BreakinCycles fixture."""
+
+    def test_step_returns_correct_step(self, BreakinCycles_fixture, benchmark):
+        """step(1) in cycle 0 returns Step 5."""
+        data = benchmark(lambda: BreakinCycles_fixture.cycle(0).step(1).data)
+        assert (data["Step"] == 5).all()
+
+    def test_multi_step_returns_multiple_steps(self, BreakinCycles_fixture, benchmark):
+        """step(range(1, 4)) returns Steps 5, 6, 7."""
+        data = benchmark(lambda: BreakinCycles_fixture.cycle(0).step(range(1, 4)).data)
+        assert (data["Step"].unique() == [5, 6, 7]).all()
+
+    def test_cycle_returns_correct_cycle(self, BreakinCycles_fixture, benchmark):
+        """cycle(2) returns only cycle 2 data with zeroed time and capacity."""
+        data = benchmark(lambda: BreakinCycles_fixture.cycle(2).data)
+        assert (data["Cycle"] == 2).all()
+        assert (data["Step"].unique() == [4, 5, 6, 7]).all()
+        assert data["Cycle Time [s]"][0] == 0
+        assert data["Cycle Capacity [Ah]"][0] == 0
+
+    def test_negative_cycle_index_selects_last(self, BreakinCycles_fixture, benchmark):
+        """cycle(-1) returns the last cycle."""
+        data = benchmark(lambda: BreakinCycles_fixture.cycle(-1).data)
+        assert (data["Cycle"] == 4).all()
+        assert (data["Step"].unique() == [4, 5, 6, 7]).all()
+
+    def test_negative_step_index_selects_last(self, BreakinCycles_fixture, benchmark):
+        """step(-1) returns the last step event in the cycle."""
+        data = benchmark(lambda: BreakinCycles_fixture.cycle(0).step(-1).data)
+        assert (data["Step"] == 7).all()
+
+    def test_all_steps_returns_full_cycle(self, BreakinCycles_fixture, benchmark):
+        """step() with no index returns all step events."""
+        data = benchmark(lambda: BreakinCycles_fixture.cycle(0).step().data)
+        assert (data["Cycle"] == 0).all()
+        assert (data["Step"].unique() == [4, 5, 6, 7]).all()
+
+    def test_zeroed_columns_reset_at_each_level(self, BreakinCycles_fixture):
+        """Time and Capacity columns are zeroed at each filtering level."""
+        exp = BreakinCycles_fixture
+        cycle = exp.cycle(0)
+        step = cycle.step(0)
+        assert exp.get("Experiment Time [s]")[0] == 0
+        assert exp.get("Experiment Capacity [Ah]")[0] == 0
+        assert cycle.get("Cycle Time [s]")[0] == 0
+        assert cycle.get("Cycle Capacity [Ah]")[0] == 0
+        assert step.get("Step Time [s]")[0] == 0
+        assert step.get("Step Capacity [Ah]")[0] == 0
+
+    def test_multiple_indices_selects_union(self, BreakinCycles_fixture):
+        """Multiple integer indices select the union of those step events."""
+        data = BreakinCycles_fixture.cycle(0).step(0, 1, 2).data
+        assert sorted(data["Step"].unique().to_list()) == [4, 5, 6]
+
+    def test_multiple_indices_range_and_slice_combined(self, BreakinCycles_fixture):
+        """Combining an integer and a slice index selects their union."""
+        data = BreakinCycles_fixture.cycle(0).step(0, slice(2, 4)).data
+        assert set(data["Step"].unique().to_list()) == {4, 6, 7}
+
+
+class TestChargeDischargeRest:
+    """Integration tests for charge(), discharge(), rest(), chargeordischarge()."""
+
+    def test_charge_returns_positive_current(self, BreakinCycles_fixture, benchmark):
+        """charge(0) returns only positive-current rows."""
+        data = benchmark(lambda: BreakinCycles_fixture.cycle(0).charge(0).data)
+        assert (data["Step"] == 6).all()
+        assert (data["Current [A]"] > 0).all()
+
+    def test_discharge_returns_negative_current(self, BreakinCycles_fixture, benchmark):
+        """discharge(0) returns only negative-current rows."""
+        data = benchmark(lambda: BreakinCycles_fixture.cycle(0).discharge(0).data)
+        assert (data["Step"] == 4).all()
+        assert (data["Current [A]"] < 0).all()
+        with pytest.raises(ValueError):
+            BreakinCycles_fixture.cycle(6).data
+
+    def test_chargeordischarge_returns_nonzero_current(
+        self, BreakinCycles_fixture, benchmark
+    ):
+        """Chargeordischarge selects both charge and discharge events by index."""
+        data = benchmark(
+            lambda: BreakinCycles_fixture.cycle(0).chargeordischarge(0).data
+        )
+        assert (data["Step"] == 4).all()
+        assert (data["Current [A]"] < 0).all()
+        data = BreakinCycles_fixture.cycle(0).chargeordischarge(1).data
+        assert (data["Step"] == 6).all()
+        assert (data["Current [A]"] > 0).all()
+
+    def test_rest_returns_zero_current(self, BreakinCycles_fixture, benchmark):
+        """rest(0) and rest(1) return zero-current rows at the expected steps."""
+        data = benchmark(lambda: BreakinCycles_fixture.cycle(0).rest(0).data)
+        assert (data["Step"] == 5).all()
+        assert (data["Current [A]"] == 0).all()
+        data = BreakinCycles_fixture.cycle(0).rest(1).data
+        assert (data["Step"] == 7).all()
+        assert (data["Current [A]"] == 0).all()
+
+
+class TestConstantFilters:
+    """Integration tests for constant_current() and constant_voltage()."""
+
+    def test_constant_current_returns_target_rows(
+        self, BreakinCycles_fixture, benchmark
+    ):
+        """constant_current(target=0.004) returns rows within the tolerance band."""
+        data = benchmark(
+            lambda: BreakinCycles_fixture.constant_current(1, target=0.004).data
+        )
+        assert np.isclose(data["Current [A]"].to_numpy().mean(), 0.004, rtol=0.001)
+        assert data["Current [A]"].min() > 0.004 - 0.004 * 0.001
+        assert data["Current [A]"].max() < 0.004 + 0.004 * 0.001
+
+    def test_constant_voltage_returns_target_rows(
+        self, BreakinCycles_fixture, benchmark
+    ):
+        """constant_voltage(target=4.2) returns rows within the tolerance band."""
+        data = benchmark(
+            lambda: BreakinCycles_fixture.constant_voltage(1, target=4.2).data
+        )
+        assert np.isclose(data["Voltage [V]"].to_numpy().mean(), 4.2, rtol=0.001)
+        assert data["Voltage [V]"].min() > 4.195
+        assert data["Voltage [V]"].max() < 4.2
+
+
+class TestSlicing:
+    """Integration tests for slice-based index selection."""
+
+    def test_slice_positive_bounds_selects_range(self, BreakinCycles_fixture):
+        """slice(0, 2) selects the first two step events."""
+        data = BreakinCycles_fixture.cycle(0).step(slice(0, 2)).data
+        assert sorted(data["Step"].unique().to_list()) == [4, 5]
+
+    def test_slice_negative_bounds_selects_from_end(self, BreakinCycles_fixture):
+        """slice(-2, None) selects the last two step events."""
+        data = BreakinCycles_fixture.cycle(0).step(slice(-2, None)).data
+        assert sorted(data["Step"].unique().to_list()) == [6, 7]
+
+    def test_slice_mixed_bounds_selects_intersection(self, BreakinCycles_fixture):
+        """slice(-3, 3) satisfies both negative start and positive stop bounds."""
+        data = BreakinCycles_fixture.cycle(0).step(slice(-3, 3)).data
+        assert sorted(data["Step"].unique().to_list()) == [5, 6]
+
+    def test_slice_step_greater_than_one_strides(self, BreakinCycles_fixture):
+        """slice(0, None, 2) selects every other step event."""
+        data = BreakinCycles_fixture.cycle(0).step(slice(0, None, 2)).data
+        assert sorted(data["Step"].unique().to_list()) == [4, 6]
+
+    def test_slice_negative_start_open_ended(self, BreakinCycles_fixture):
+        """slice(-2, None) selects the last two step events."""
+        data = BreakinCycles_fixture.cycle(0).step(slice(-2, None)).data
+        assert sorted(data["Step"].unique().to_list()) == [6, 7]
+
+    def test_slice_negative_start_with_step_greater_than_one(
+        self, BreakinCycles_fixture
+    ):
+        """slice(-4, None, 2) strides from the fourth-to-last event."""
+        data = BreakinCycles_fixture.cycle(0).step(slice(-4, None, 2)).data
+        assert sorted(data["Step"].unique().to_list()) == [4, 6]
+
+    def test_slice_zero_stop_returns_empty(self, BreakinCycles_fixture):
+        """slice(0, 0) produces an empty result."""
+        with pytest.raises(ValueError, match="No data exists for this filter"):
+            BreakinCycles_fixture.cycle(0).step(slice(0, 0)).data
+
+    def test_slice_positive_start_zero_stop_returns_empty(self, BreakinCycles_fixture):
+        """slice(1, 0) produces an empty result."""
+        with pytest.raises(ValueError, match="No data exists for this filter"):
+            BreakinCycles_fixture.cycle(0).step(slice(1, 0)).data
+
+    def test_slice_negative_step_raises_error(self, BreakinCycles_fixture):
+        """A negative step value raises ValueError."""
+        with pytest.raises(ValueError, match="Negative step is not supported"):
+            BreakinCycles_fixture.cycle(0).step(slice(3, 0, -1)).data
+
+
+class TestIncludePrecedingPoint:
+    """Tests for include_preceding_point across all singular filter methods."""
+
+    def _assert_preceding_row_prepended(self, data_without, data_with, full_data):
+        assert len(data_with) == len(data_without) + 1
+        match = (
+            (full_data["Time [s]"] == data_without["Time [s]"][0])
+            & (full_data["Step"] == data_without["Step"][0])
+            & (full_data["Event"] == data_without["Event"][0])
+        )
+        idx = int(np.where(match)[0][0])
+        assert idx > 0
+        assert data_with["Time [s]"][0] == full_data["Time [s]"][idx - 1]
+
+    def test_step_prepends_preceding_row(self, BreakinCycles_fixture):
+        """Step with include_preceding_point prepends exactly one row."""
+        cycle0 = BreakinCycles_fixture.cycle(0)
+        data_without = cycle0.step(1).data
+        data_with = cycle0.step(1, include_preceding_point=True).data
+        self._assert_preceding_row_prepended(data_without, data_with, cycle0.data)
+        assert (
+            data_with.tail(len(data_without))["Time [s]"].to_list()
+            == data_without["Time [s]"].to_list()
+        )
+
+    def test_charge_prepends_preceding_row(self, BreakinCycles_fixture):
+        """Charge with include_preceding_point prepends exactly one row."""
+        cycle0 = BreakinCycles_fixture.cycle(0)
+        data_without = cycle0.charge(0).data
+        data_with = cycle0.charge(0, include_preceding_point=True).data
+        self._assert_preceding_row_prepended(data_without, data_with, cycle0.data)
+
+    def test_discharge_prepends_preceding_row(self, BreakinCycles_fixture):
+        """Discharge with include_preceding_point prepends exactly one row."""
+        data_without = BreakinCycles_fixture.discharge(1).data
+        data_with = BreakinCycles_fixture.discharge(
+            1, include_preceding_point=True
+        ).data
+        self._assert_preceding_row_prepended(
+            data_without, data_with, BreakinCycles_fixture.data
+        )
+
+    def test_rest_prepends_preceding_row(self, BreakinCycles_fixture):
+        """Rest with include_preceding_point prepends exactly one row."""
+        cycle0 = BreakinCycles_fixture.cycle(0)
+        data_without = cycle0.rest(0).data
+        data_with = cycle0.rest(0, include_preceding_point=True).data
+        self._assert_preceding_row_prepended(data_without, data_with, cycle0.data)
+
+    def test_chargeordischarge_prepends_preceding_row(self, BreakinCycles_fixture):
+        """Chargeordischarge with include_preceding_point prepends exactly one row."""
+        cycle0 = BreakinCycles_fixture.cycle(0)
+        data_without = cycle0.chargeordischarge(1).data
+        data_with = cycle0.chargeordischarge(1, include_preceding_point=True).data
+        self._assert_preceding_row_prepended(data_without, data_with, cycle0.data)
+
+    def test_cycle_prepends_preceding_row(self, BreakinCycles_fixture):
+        """Cycle with include_preceding_point prepends exactly one row."""
+        data_without = BreakinCycles_fixture.cycle(1).data
+        data_with = BreakinCycles_fixture.cycle(1, include_preceding_point=True).data
+        self._assert_preceding_row_prepended(
+            data_without, data_with, BreakinCycles_fixture.data
+        )
+
+    @pytest.mark.parametrize("exp_name", ["Break-in Cycles", "Discharge Pulses"])
+    def test_procedure_experiment_prepends_preceding_row(
+        self, procedure_fixture, exp_name
+    ):
+        """Procedure.experiment with include_preceding_point prepends one row."""
+        data_without = procedure_fixture.experiment(exp_name).data
+        data_with = procedure_fixture.experiment(
+            exp_name, include_preceding_point=True
+        ).data
+        self._assert_preceding_row_prepended(
+            data_without, data_with, procedure_fixture.data
+        )
+
+    def test_constant_current_prepends_preceding_row(self, generic_experiment):
+        """constant_current with include_preceding_point prepends exactly one row."""
+        data_without = generic_experiment.constant_current(1, target=1.0).data
+        data_with = generic_experiment.constant_current(
+            1, target=1.0, include_preceding_point=True
+        ).data
+        full_data = generic_experiment.data
+        assert len(data_with) == len(data_without) + 1
+        match = (full_data["Time [s]"] == data_without["Time [s]"][0]) & (
+            full_data["Event"] == data_without["Event"][0]
+        )
+        idx = int(np.where(match)[0][0])
+        assert idx > 0
+        assert data_with["Time [s]"][0] == full_data["Time [s]"][idx - 1]
+
+    def test_constant_voltage_prepends_preceding_row(self, generic_experiment):
+        """constant_voltage with include_preceding_point prepends exactly one row."""
+        data_without = generic_experiment.constant_voltage(1, target=4.2).data
+        data_with = generic_experiment.constant_voltage(
+            1, target=4.2, include_preceding_point=True
+        ).data
+        full_data = generic_experiment.data
+        assert len(data_with) == len(data_without) + 1
+        match = (full_data["Time [s]"] == data_without["Time [s]"][0]) & (
+            full_data["Event"] == data_without["Event"][0]
+        )
+        idx = int(np.where(match)[0][0])
+        assert idx > 0
+        assert data_with["Time [s]"][0] == full_data["Time [s]"][idx - 1]
+
+
+class TestIterators:
+    """Tests for iter_* methods and their include_preceding_point behaviour."""
+
+    def _assert_iter_preceding_row(self, results_without, results_with, full_data):
+        assert len(results_with) == len(results_without)
+        assert len(results_with[0].data) == len(results_without[0].data) + 1
+        first_row = results_without[0].data
+        match = (
+            (full_data["Time [s]"] == first_row["Time [s]"][0])
+            & (full_data["Step"] == first_row["Step"][0])
+            & (full_data["Event"] == first_row["Event"][0])
+        )
+        idx = int(np.where(match)[0][0])
+        assert idx > 0
+        assert results_with[0].data["Time [s]"][0] == full_data["Time [s]"][idx - 1]
+
+    def test_iter_step_single_index(self, BreakinCycles_fixture):
+        """iter_step(0) yields one result containing step event 0."""
+        results = list(BreakinCycles_fixture.cycle(0).iter_step(0))
+        assert len(results) == 1
+        assert results[0].data["Step"].unique().to_list() == [4]
+
+    def test_iter_step_range(self, BreakinCycles_fixture):
+        """iter_step(range(2)) yields two results, one per step event."""
+        results = list(BreakinCycles_fixture.cycle(0).iter_step(range(2)))
+        assert len(results) == 2
+        assert results[0].data["Step"].unique().to_list() == [4]
+        assert results[1].data["Step"].unique().to_list() == [5]
+
+    def test_iter_step_slice(self, BreakinCycles_fixture):
+        """iter_step(slice(0, 2)) yields one result per selected step event."""
+        results = list(BreakinCycles_fixture.cycle(0).iter_step(slice(0, 2)))
+        assert len(results) == 2
+        assert results[0].data["Step"].unique().to_list() == [4]
+        assert results[1].data["Step"].unique().to_list() == [5]
+
+    def test_iter_charge_yields_all_groups(self, BreakinCycles_fixture):
+        """iter_charge() yields one result per charge event."""
+        results = list(BreakinCycles_fixture.iter_charge())
+        assert len(results) == 5
+        for item in results:
+            assert item.data["Step"].unique().to_list() == [6]
+            assert (item.data["Current [A]"] > 0).all()
+
+    def test_iter_discharge_yields_all_groups(self, BreakinCycles_fixture):
+        """iter_discharge() yields one result per discharge event."""
+        results = list(BreakinCycles_fixture.iter_discharge())
+        assert len(results) == 5
+        for item in results:
+            assert item.data["Step"].unique().to_list() == [4]
+            assert (item.data["Current [A]"] < 0).all()
+
+    def test_iter_rest_yields_all_groups(self, BreakinCycles_fixture):
+        """iter_rest() yields one result per rest event."""
+        results = list(BreakinCycles_fixture.iter_rest())
+        assert len(results) == 10
+        for item in results:
+            assert (item.data["Current [A]"] == 0).all()
+
+    def test_iter_chargeordischarge_yields_all_groups(self, BreakinCycles_fixture):
+        """iter_chargeordischarge() yields one result per non-rest event."""
+        results = list(BreakinCycles_fixture.iter_chargeordischarge())
+        assert len(results) == 10
+        for item in results:
+            assert (item.data["Current [A]"].abs() > 0).all()
+
+    def test_iter_cycle_yields_all_cycles(self, BreakinCycles_fixture):
+        """iter_cycle() yields one result per cycle in order."""
+        results = list(BreakinCycles_fixture.iter_cycle())
+        assert len(results) == 5
+        assert [c.data["Cycle"].unique()[0] for c in results] == [0, 1, 2, 3, 4]
+
+    def test_iter_step_with_include_preceding_point(self, BreakinCycles_fixture):
+        """iter_step with include_preceding_point adds one row to each result."""
+        cycle0 = BreakinCycles_fixture.cycle(0)
+        results_without = list(cycle0.iter_step(slice(1, 2)))
+        results_with = list(cycle0.iter_step(slice(1, 2), include_preceding_point=True))
+        self._assert_iter_preceding_row(results_without, results_with, cycle0.data)
+
+    def test_iter_charge_with_include_preceding_point(self, BreakinCycles_fixture):
+        """iter_charge with include_preceding_point adds one row to each result."""
+        cycle0 = BreakinCycles_fixture.cycle(0)
+        results_without = list(cycle0.iter_charge(slice(0, 1)))
+        results_with = list(
+            cycle0.iter_charge(slice(0, 1), include_preceding_point=True)
+        )
+        self._assert_iter_preceding_row(results_without, results_with, cycle0.data)
+
+    def test_iter_discharge_with_include_preceding_point(self, BreakinCycles_fixture):
+        """iter_discharge with include_preceding_point adds one row to each result."""
+        results_without = list(BreakinCycles_fixture.iter_discharge(slice(1, 2)))
+        results_with = list(
+            BreakinCycles_fixture.iter_discharge(
+                slice(1, 2), include_preceding_point=True
+            )
+        )
+        self._assert_iter_preceding_row(
+            results_without, results_with, BreakinCycles_fixture.data
+        )
+
+    def test_iter_rest_with_include_preceding_point(self, BreakinCycles_fixture):
+        """iter_rest with include_preceding_point adds one row to each result."""
+        cycle0 = BreakinCycles_fixture.cycle(0)
+        results_without = list(cycle0.iter_rest(slice(0, 1)))
+        results_with = list(cycle0.iter_rest(slice(0, 1), include_preceding_point=True))
+        self._assert_iter_preceding_row(results_without, results_with, cycle0.data)
+
+    def test_iter_chargeordischarge_with_include_preceding_point(
+        self, BreakinCycles_fixture
+    ):
+        """iter_chargeordischarge with include_preceding_point adds one row each."""
+        cycle0 = BreakinCycles_fixture.cycle(0)
+        results_without = list(cycle0.iter_chargeordischarge(slice(1, 2)))
+        results_with = list(
+            cycle0.iter_chargeordischarge(slice(1, 2), include_preceding_point=True)
+        )
+        self._assert_iter_preceding_row(results_without, results_with, cycle0.data)
+
+    def test_iter_cycle_with_include_preceding_point(self, BreakinCycles_fixture):
+        """iter_cycle with include_preceding_point adds one row to each result."""
+        results_without = list(BreakinCycles_fixture.iter_cycle(slice(1, 2)))
+        results_with = list(
+            BreakinCycles_fixture.iter_cycle(slice(1, 2), include_preceding_point=True)
+        )
+        self._assert_iter_preceding_row(
+            results_without, results_with, BreakinCycles_fixture.data
+        )
+
+    def test_iter_constant_current_yields_all_groups(self, generic_experiment):
+        """iter_constant_current yields one result per matching current group."""
+        results = list(generic_experiment.iter_constant_current(target=1.0))
+        assert len(results) == 4
+        for r in results:
+            assert (r.data["Current [A]"] == 1.0).all()
+
+        results_neg = list(generic_experiment.iter_constant_current(target=-1.0))
+        assert len(results_neg) == 2
+        for r in results_neg:
+            assert (r.data["Current [A]"] == -1.0).all()
+
+    def test_iter_constant_voltage_yields_all_groups(self, generic_experiment):
+        """iter_constant_voltage yields one result per matching voltage group."""
+        results = list(generic_experiment.iter_constant_voltage(target=4.2))
+        assert len(results) == 4
+        for r in results:
+            assert (r.data["Voltage [V]"] == 4.2).all()
+
+
+class TestGenericExperiment:
+    """Integration tests using the synthetic generic_experiment fixture."""
+
+    def test_cycle_filters_outer_and_inner_cycles(self, generic_experiment):
+        """Outer and inner cycle filtering both return the correct row ranges."""
+        assert generic_experiment.cycle(0).data["Time [s]"].to_list() == list(range(26))
+        assert generic_experiment.cycle(1).data["Time [s]"].to_list() == list(
+            range(26, 52)
+        )
+        assert generic_experiment.cycle(-1).data["Time [s]"].to_list() == list(
+            range(26, 52)
+        )
+
+        next_cycle = generic_experiment.cycle(1)
+        assert next_cycle.cycle_info == [(1, 2, 2)]
+        assert next_cycle.cycle(0).data["Time [s]"].to_list() == list(range(26, 32))
+        assert next_cycle.cycle(1).data["Time [s]"].to_list() == list(range(32, 38))
+        assert next_cycle.cycle(2).data["Time [s]"].to_list() == list(range(38, 52))
+
+    def test_cycle_inferred_from_step_decrease(self, generic_experiment):
+        """When cycle_info is empty, cycles are inferred from step number decreases."""
+        generic_experiment.cycle_info = []
+        assert generic_experiment.cycle(0).data["Time [s]"].to_list() == list(range(6))
+        assert generic_experiment.cycle(1).data["Time [s]"].to_list() == list(
+            range(6, 26)
+        )
+        assert generic_experiment.cycle(2).data["Time [s]"].to_list() == list(
+            range(26, 32)
+        )
+        assert generic_experiment.cycle(-1).data["Time [s]"].to_list() == list(
+            range(32, 52)
+        )
+
+    def test_cycle_chaining_selects_correct_rows(self, generic_experiment):
+        """Chained cycle() calls filter outer then inner cycles correctly."""
+        data = generic_experiment.cycle(1).cycle(2).data
+        assert data["Time [s]"].to_list() == list(range(38, 52))
+
+    def test_step_selects_by_event_group(self, generic_experiment):
+        """step() selects rows by event group index."""
+        data = generic_experiment.step(0).data
+        assert data["Time [s]"].to_list() == [0, 1, 2]
+        assert (data["Step"] == 1).all()
+
+        data = generic_experiment.step(2).data
+        assert data["Time [s]"].to_list() == [6, 7, 8]
+
+        data = generic_experiment.step(6).data
+        assert data["Time [s]"].to_list() == [26, 27, 28]
+
+        data = generic_experiment.step(0, 1).data
+        assert data["Time [s]"].to_list() == list(range(6))
+
+    def test_charge_selects_positive_current_groups(self, generic_experiment):
+        """charge() selects groups by positive-current event index."""
+        data = generic_experiment.charge(0).data
+        assert data["Time [s]"].to_list() == [0, 1, 2]
+        assert (data["Step"] == 1).all()
+
+        data = generic_experiment.charge(1).data
+        assert data["Time [s]"].to_list() == [3, 4, 5]
+        assert (data["Step"] == 2).all()
+
+        data = generic_experiment.charge(4).data
+        assert data["Time [s]"].to_list() == [26, 27, 28]
+
+    def test_discharge_selects_negative_current_groups(self, generic_experiment):
+        """discharge() selects groups by negative-current event index."""
+        data = generic_experiment.discharge(0).data
+        assert data["Time [s]"].to_list() == list(range(12, 22))
+        assert (data["Step"] == 3).all()
+        assert (data["Current [A]"] < 0).all()
+
+        data = generic_experiment.discharge(1).data
+        assert data["Time [s]"].to_list() == list(range(38, 48))
+
+    def test_rest_selects_zero_current_groups(self, generic_experiment):
+        """rest() selects groups where current is zero."""
+        data = generic_experiment.rest(0).data
+        assert data["Time [s]"].to_list() == list(range(22, 26))
+        assert (data["Step"] == 4).all()
+        assert (data["Current [A]"] == 0).all()
+
+    def test_constant_current_selects_by_target(self, generic_experiment):
+        """constant_current(target) selects groups near the specified current."""
+        data = generic_experiment.constant_current(0, target=1).data
+        assert data["Time [s]"].to_list() == [0, 1, 2]
+        assert (data["Current [A]"] == 1.0).all()
+
+        data = generic_experiment.constant_current(0, target=-1).data
+        assert data["Time [s]"].to_list() == list(range(12, 22))
+        assert (data["Current [A]"] == -1.0).all()
+
+    def test_constant_voltage_selects_by_target(self, generic_experiment):
+        """constant_voltage(target) selects groups near the specified voltage."""
+        data = generic_experiment.constant_voltage(0, target=4.2).data
+        assert data["Time [s]"].to_list() == [3, 4, 5]
+
+    def test_iter_filters_yield_correct_group_counts(self, generic_experiment):
+        """All iter_* methods yield the expected number of groups."""
+        assert len(list(generic_experiment.iter_step())) == 12
+        assert len(list(generic_experiment.iter_charge())) == 8
+        assert len(list(generic_experiment.iter_discharge())) == 2
+        assert len(list(generic_experiment.iter_rest())) == 2
+        assert len(list(generic_experiment.iter_chargeordischarge())) == 10
+
+
+class TestParametricConstantFilters:
+    """Tests for constant_current/constant_voltage with explicit target and rtol."""
+
+    def test_constant_voltage_with_target_excludes_other_level(self, multilevel_cv):
+        """Only the 4.2 V hold is returned; negative target matches nothing."""
+        data = multilevel_cv.constant_voltage(0, target=4.2, rtol=0.001).data
+        assert data["Voltage [V]"].min() >= 4.2 * 0.999
+        assert data["Voltage [V]"].max() <= 4.2 * 1.001
+        assert len(data) == 100
+        assert multilevel_cv.constant_voltage(target=-4.2).lf.collect().is_empty()
+
+    def test_constant_current_with_target_excludes_other_level(self, multilevel_cc):
+        """Only the 1.0 A hold is returned; negative target matches nothing."""
+        data = multilevel_cc.constant_current(0, target=1.0, rtol=0.001).data
+        assert data["Current [A]"].min() >= 1.0 * 0.999
+        assert data["Current [A]"].max() <= 1.0 * 1.001
+        assert len(data) == 100
+        assert multilevel_cc.constant_current(target=-1.0).lf.collect().is_empty()
+
+    def test_constant_voltage_no_target_uses_dominant_level(self, multilevel_cv):
+        """Without a target, both indexed groups return the dominant (4.2 V) level."""
+        data_0 = multilevel_cv.constant_voltage(0).data
+        data_1 = multilevel_cv.constant_voltage(1).data
+        assert np.isclose(data_0["Voltage [V]"].mean(), 4.2, rtol=0.001)
+        assert np.isclose(data_1["Voltage [V]"].mean(), 4.2, rtol=0.001)
+        with pytest.raises(ValueError):
+            multilevel_cv.constant_voltage(2).data
+
+    def test_constant_voltage_rtol_controls_band_width(self):
+        """Wider rtol includes more rows; narrower rtol excludes borderline rows."""
+        df = pl.DataFrame(
+            {
+                "Time [s]": list(range(20)),
+                "Step": [0] * 20,
+                "Event": [0] * 10 + [1] * 10,
+                "Current [A]": [0.0] * 20,
+                "Voltage [V]": [4.2] * 10 + [4.19] * 10,
+                "Capacity [Ah]": [0.0] * 20,
+            }
+        )
+        exp = filters.Experiment(
+            lf=df,
+            info={},
+            step_descriptions={"Step": [0], "Description": ["Test"]},
+            cycle_info=[],
+        )
+        wide = exp.constant_voltage(target=4.2, rtol=0.003).data
+        narrow = exp.constant_voltage(target=4.2, rtol=0.001).data
+        assert len(wide) == 20
+        assert len(narrow) == 10
+        assert narrow["Voltage [V]"].min() == 4.2
+
+    def test_constant_voltage_index_with_target_selects_first_group(
+        self, multilevel_cv
+    ):
+        """constant_voltage(0, target=X) returns only the first matching hold."""
+        first = multilevel_cv.constant_voltage(0, target=4.2, rtol=0.001).data
+        both = multilevel_cv.constant_voltage(target=4.2, rtol=0.001).data
+        assert len(first) < len(both)
+        assert len(first) == 100
+        assert first["Voltage [V]"].min() >= 4.2 * 0.999

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -233,6 +233,7 @@ class TestSliceToMaskExpr:
             (slice(-3, 0), [7, 8, 9]),
             (slice(-5, None, 2), [5, 7, 9]),
             (slice(-5, -1, 2), [5, 7]),
+            (slice(None, None), list(range(10))),
         ],
     )
     def test_slice_to_mask_selects_correct_values(self, sl, expected_values):
@@ -260,6 +261,11 @@ class TestSliceToMaskExpr:
         ):
             _slice_to_mask_expr(slice(None, -2), asc_rank, None)
 
+        with pytest.raises(
+            ValueError, match="Negative slice start requires a descending rank"
+        ):
+            _slice_to_mask_expr(slice(-2, None, 2), asc_rank, None)
+
 
 class TestFilterBuildMask:
     """Unit tests for Filter._build_mask."""
@@ -277,6 +283,12 @@ class TestFilterBuildMask:
             (filters._Filter("Event", pl.col("Current [A]") == 0), (), [1, 1, 3, 3]),
             (filters._Filter("Event", pl.col("Current [A]") == 0), (0,), [1, 1]),
             (filters._Filter("Event", pl.col("Current [A]") == 0), (1,), [3, 3]),
+            (filters._Filter("Event"), ("unsupported",), [0, 0, 1, 1, 2, 2, 3, 3]),
+            (
+                filters._Filter("Event", pl.col("Current [A]") > 0),
+                ("unsupported",),
+                [0, 0],
+            ),
         ],
     )
     def test_filter_build_mask_selects_expected_events(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -119,30 +119,27 @@ def test_cycle(BreakinCycles_fixture, benchmark):
 
 
 def test_constant_current(BreakinCycles_fixture, benchmark):
-    """Test backward-compatible constant_current with no target/rtol."""
+    """Test the constant current method."""
 
     def constant_current():
-        return BreakinCycles_fixture.constant_current(1).data
+        return BreakinCycles_fixture.constant_current(1, target=0.004).data
 
     data = benchmark(constant_current)
-    assert len(data) > 0
-    # No-target branch uses global mode of non-zero current; all returned rows
-    # must be within 0.1% of that mode.
-    mode_val = data["Current [A]"].mode()[0]
-    assert ((data["Current [A]"] - mode_val).abs() <= abs(mode_val) * 0.001).all()
+    assert np.isclose(data["Current [A]"].to_numpy().mean(), 0.004, rtol=0.001)
+    assert data["Current [A]"].min() > 0.004 - 0.004 * 0.001
+    assert data["Current [A]"].max() < 0.004 + 0.004 * 0.001
 
 
 def test_constant_voltage(BreakinCycles_fixture, benchmark):
-    """Test backward-compatible constant_voltage with no target/rtol."""
+    """Test the constant voltage method."""
 
     def constant_voltage():
-        return BreakinCycles_fixture.constant_voltage(1).data
+        return BreakinCycles_fixture.constant_voltage(1, target=4.2).data
 
     data = benchmark(constant_voltage)
-    assert len(data) > 0
-    # No-target branch uses global mode; all rows must be within 0.1% of mode.
-    mode_val = data["Voltage [V]"].mode()[0]
-    assert ((data["Voltage [V]"] - mode_val).abs() <= abs(mode_val) * 0.001).all()
+    assert np.isclose(data["Voltage [V]"].to_numpy().mean(), 4.2, rtol=0.001)
+    assert data["Voltage [V]"].min() > 4.195
+    assert data["Voltage [V]"].max() < 4.2
 
 
 def test_all_steps(BreakinCycles_fixture, benchmark):
@@ -170,121 +167,627 @@ def test_zeroed_columns(BreakinCycles_fixture):
     assert step_filtered_data.get("Step Capacity [Ah]")[0] == 0
 
 
+def test_slice_positive_only(BreakinCycles_fixture):
+    """Test slicing with positive start and stop."""
+    data = BreakinCycles_fixture.cycle(0).step(slice(0, 2)).data
+    step_values = sorted(data["Step"].unique().to_list())
+    assert step_values == [4, 5]
+
+
+def test_slice_negative_only(BreakinCycles_fixture):
+    """Test slicing with negative bounds."""
+    data = BreakinCycles_fixture.cycle(0).step(slice(-2, None)).data
+    step_values = sorted(data["Step"].unique().to_list())
+    assert step_values == [6, 7]
+
+
+def test_slice_mixed_bounds(BreakinCycles_fixture):
+    """Test slicing with mixed positive and negative bounds."""
+    data = BreakinCycles_fixture.cycle(0).step(slice(-3, 3)).data
+    step_values = sorted(data["Step"].unique().to_list())
+    assert step_values == [5, 6]
+
+
+def test_slice_with_step_greater_than_one(BreakinCycles_fixture):
+    """Test slicing with step > 1."""
+    data = BreakinCycles_fixture.cycle(0).step(slice(0, None, 2)).data
+    step_values = sorted(data["Step"].unique().to_list())
+    assert step_values == [4, 6]
+
+
+def test_slice_negative_start_open_ended(BreakinCycles_fixture):
+    """Test slice(-n, 0) which should be open-ended from -n to end."""
+    data = BreakinCycles_fixture.cycle(0).step(slice(-2, None)).data
+    step_values = sorted(data["Step"].unique().to_list())
+    assert step_values == [6, 7]
+
+
+def test_slice_empty_result_zero_stop(BreakinCycles_fixture):
+    """Test slice(k, 0) for k >= 0 which should give empty result."""
+    with pytest.raises(ValueError, match="No data exists for this filter"):
+        BreakinCycles_fixture.cycle(0).step(slice(0, 0)).data
+
+
+def test_slice_empty_result_positive_stop_zero(BreakinCycles_fixture):
+    """Test slice(1, 0) which should give empty result."""
+    with pytest.raises(ValueError, match="No data exists for this filter"):
+        BreakinCycles_fixture.cycle(0).step(slice(1, 0)).data
+
+
+def test_slice_step_greater_than_one_with_negative_start(BreakinCycles_fixture):
+    """Test slice with step > 1 and negative start."""
+    data = BreakinCycles_fixture.cycle(0).step(slice(-4, None, 2)).data
+    step_values = sorted(data["Step"].unique().to_list())
+    assert step_values == [4, 6]
+
+
+def test_include_preceding_point_step(BreakinCycles_fixture):
+    """Test include_preceding_point with step filter."""
+    cycle0 = BreakinCycles_fixture.cycle(0)
+    data_without = cycle0.step(1).data
+    data_with = cycle0.step(1, include_preceding_point=True).data
+
+    assert len(data_with) == len(data_without) + 1
+    # Check content of the prepended row: it should match the row before
+    # Step 1 in Cycle 0
+    c0_data = cycle0.data
+    # Find the index of the first row of data_without in c0_data
+    # We match on Time [s], Step, and Event to be unique
+    match = (
+        (c0_data["Time [s]"] == data_without["Time [s]"][0])
+        & (c0_data["Step"] == data_without["Step"][0])
+        & (c0_data["Event"] == data_without["Event"][0])
+    )
+    idx = int(np.where(match)[0][0])
+    assert idx > 0
+    assert data_with["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
+    assert data_with["Step"][0] == c0_data["Step"][idx - 1]
+    # Tail should match
+    assert (
+        data_with.tail(len(data_without))["Time [s]"].to_list()
+        == data_without["Time [s]"].to_list()
+    )
+
+
+def test_include_preceding_point_charge(BreakinCycles_fixture):
+    """Test include_preceding_point with charge filter."""
+    cycle0 = BreakinCycles_fixture.cycle(0)
+    data_without = cycle0.charge(0).data
+    data_with = cycle0.charge(0, include_preceding_point=True).data
+
+    assert len(data_with) == len(data_without) + 1
+    c0_data = cycle0.data
+    match = (
+        (c0_data["Time [s]"] == data_without["Time [s]"][0])
+        & (c0_data["Step"] == data_without["Step"][0])
+        & (c0_data["Event"] == data_without["Event"][0])
+    )
+    idx = int(np.where(match)[0][0])
+    assert idx > 0
+    assert data_with["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
+
+
+def test_include_preceding_point_discharge(BreakinCycles_fixture):
+    """Test include_preceding_point with discharge filter."""
+    # Use discharge(1) at experiment level to ensure a predecessor exists
+    # (Step 4 of cycle 1, predecessor is Step 7 of cycle 0)
+    data_without = BreakinCycles_fixture.discharge(1).data
+    data_with = BreakinCycles_fixture.discharge(1, include_preceding_point=True).data
+
+    assert len(data_with) == len(data_without) + 1
+    full_data = BreakinCycles_fixture.data
+    match = (
+        (full_data["Time [s]"] == data_without["Time [s]"][0])
+        & (full_data["Step"] == data_without["Step"][0])
+        & (full_data["Event"] == data_without["Event"][0])
+    )
+    idx = int(np.where(match)[0][0])
+    assert idx > 0
+    assert data_with["Time [s]"][0] == full_data["Time [s]"][idx - 1]
+
+
+def test_include_preceding_point_rest(BreakinCycles_fixture):
+    """Test include_preceding_point with rest filter."""
+    cycle0 = BreakinCycles_fixture.cycle(0)
+    # rest(0) is Step 5, predecessor is Step 4
+    data_without = cycle0.rest(0).data
+    data_with = cycle0.rest(0, include_preceding_point=True).data
+
+    assert len(data_with) == len(data_without) + 1
+    c0_data = cycle0.data
+    match = (
+        (c0_data["Time [s]"] == data_without["Time [s]"][0])
+        & (c0_data["Step"] == data_without["Step"][0])
+        & (c0_data["Event"] == data_without["Event"][0])
+    )
+    idx = int(np.where(match)[0][0])
+    assert idx > 0
+    assert data_with["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
+
+
+def test_include_preceding_point_chargeordischarge(BreakinCycles_fixture):
+    """Test include_preceding_point with chargeordischarge filter."""
+    cycle0 = BreakinCycles_fixture.cycle(0)
+    # chargeordischarge(1) is Step 6, predecessor is Step 5
+    data_without = cycle0.chargeordischarge(1).data
+    data_with = cycle0.chargeordischarge(1, include_preceding_point=True).data
+
+    assert len(data_with) == len(data_without) + 1
+    c0_data = cycle0.data
+    match = (
+        (c0_data["Time [s]"] == data_without["Time [s]"][0])
+        & (c0_data["Step"] == data_without["Step"][0])
+        & (c0_data["Event"] == data_without["Event"][0])
+    )
+    idx = int(np.where(match)[0][0])
+    assert idx > 0
+    assert data_with["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
+
+
+def test_include_preceding_point_cycle(BreakinCycles_fixture):
+    """Test include_preceding_point with cycle filter on cycle 1."""
+    data_without = BreakinCycles_fixture.cycle(1).data
+    data_with = BreakinCycles_fixture.cycle(1, include_preceding_point=True).data
+
+    assert len(data_with) == len(data_without) + 1
+    full_data = BreakinCycles_fixture.data
+    match = (
+        (full_data["Time [s]"] == data_without["Time [s]"][0])
+        & (full_data["Step"] == data_without["Step"][0])
+        & (full_data["Event"] == data_without["Event"][0])
+    )
+    idx = int(np.where(match)[0][0])
+    assert idx > 0
+    assert data_with["Time [s]"][0] == full_data["Time [s]"][idx - 1]
+
+
+def test_iter_step_single_index(BreakinCycles_fixture):
+    """Test iter_step with a single index."""
+    cycle0 = BreakinCycles_fixture.cycle(0)
+    results = list(cycle0.iter_step(0))
+    assert len(results) == 1
+    assert results[0].data["Step"].unique().to_list() == [4]
+
+
+def test_iter_step_range(BreakinCycles_fixture):
+    """Test iter_step with a range of indices."""
+    cycle0 = BreakinCycles_fixture.cycle(0)
+    results = list(cycle0.iter_step(range(2)))
+    assert len(results) == 2
+    assert results[0].data["Step"].unique().to_list() == [4]
+    assert results[1].data["Step"].unique().to_list() == [5]
+
+
+def test_iter_step_slice(BreakinCycles_fixture):
+    """Test iter_step with a slice."""
+    cycle0 = BreakinCycles_fixture.cycle(0)
+    results = list(cycle0.iter_step(slice(0, 2)))
+    assert len(results) == 2
+    assert results[0].data["Step"].unique().to_list() == [4]
+    assert results[1].data["Step"].unique().to_list() == [5]
+
+
+def test_iter_charge(BreakinCycles_fixture):
+    """Test iter_charge at experiment level."""
+    results = list(BreakinCycles_fixture.iter_charge())
+    assert len(results) == 5
+    for item in results:
+        assert item.data["Step"].unique().to_list() == [6]
+        assert (item.data["Current [A]"] > 0).all()
+
+
+def test_iter_discharge(BreakinCycles_fixture):
+    """Test iter_discharge at experiment level."""
+    results = list(BreakinCycles_fixture.iter_discharge())
+    assert len(results) == 5
+    for item in results:
+        assert item.data["Step"].unique().to_list() == [4]
+        assert (item.data["Current [A]"] < 0).all()
+
+
+def test_iter_rest(BreakinCycles_fixture):
+    """Test iter_rest at experiment level."""
+    results = list(BreakinCycles_fixture.iter_rest())
+    assert len(results) == 10
+    for item in results:
+        assert (item.data["Current [A]"] == 0).all()
+
+
+def test_iter_chargeordischarge(BreakinCycles_fixture):
+    """Test iter_chargeordischarge at experiment level."""
+    results = list(BreakinCycles_fixture.iter_chargeordischarge())
+    assert len(results) == 10
+    for item in results:
+        assert (item.data["Current [A]"].abs() > 0).all()
+
+
+def test_iter_cycle(BreakinCycles_fixture):
+    """Test iter_cycle."""
+    results = list(BreakinCycles_fixture.iter_cycle())
+    assert len(results) == 5
+    assert [c.data["Cycle"].unique()[0] for c in results] == [0, 1, 2, 3, 4]
+
+
+def test_iter_step_with_include_preceding_point(BreakinCycles_fixture):
+    """Test iter_step with include_preceding_point."""
+    cycle0 = BreakinCycles_fixture.cycle(0)
+    # Use index 1 in cycle 0 to ensure a predecessor exists
+    results_without = list(cycle0.iter_step(slice(1, 2)))
+    results_with = list(cycle0.iter_step(slice(1, 2), include_preceding_point=True))
+
+    assert len(results_with) == len(results_without)
+    assert len(results_with[0].data) == len(results_without[0].data) + 1
+    c0_data = cycle0.data
+    first_row = results_without[0].data
+    match = (
+        (c0_data["Time [s]"] == first_row["Time [s]"][0])
+        & (c0_data["Step"] == first_row["Step"][0])
+        & (c0_data["Event"] == first_row["Event"][0])
+    )
+    idx = int(np.where(match)[0][0])
+    assert idx > 0
+    assert results_with[0].data["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
+
+
+def test_iter_charge_with_include_preceding_point(BreakinCycles_fixture):
+    """Test iter_charge with include_preceding_point."""
+    cycle0 = BreakinCycles_fixture.cycle(0)
+    # charge(0) is Step 6, predecessor is Step 5. This should work.
+    results_without = list(cycle0.iter_charge(slice(0, 1)))
+    results_with = list(cycle0.iter_charge(slice(0, 1), include_preceding_point=True))
+
+    assert len(results_with) == len(results_without)
+    assert len(results_with[0].data) == len(results_without[0].data) + 1
+    c0_data = cycle0.data
+    first_row = results_without[0].data
+    match = (
+        (c0_data["Time [s]"] == first_row["Time [s]"][0])
+        & (c0_data["Step"] == first_row["Step"][0])
+        & (c0_data["Event"] == first_row["Event"][0])
+    )
+    idx = int(np.where(match)[0][0])
+    assert idx > 0
+    assert results_with[0].data["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
+
+
+def test_iter_discharge_with_include_preceding_point(BreakinCycles_fixture):
+    """Test iter_discharge with include_preceding_point."""
+    # Use index 1 at experiment level to ensure a predecessor exists
+    results_without = list(BreakinCycles_fixture.iter_discharge(slice(1, 2)))
+    results_with = list(
+        BreakinCycles_fixture.iter_discharge(slice(1, 2), include_preceding_point=True)
+    )
+
+    assert len(results_with) == len(results_without)
+    assert len(results_with[0].data) == len(results_without[0].data) + 1
+    full_data = BreakinCycles_fixture.data
+    first_row = results_without[0].data
+    match = (
+        (full_data["Time [s]"] == first_row["Time [s]"][0])
+        & (full_data["Step"] == first_row["Step"][0])
+        & (full_data["Event"] == first_row["Event"][0])
+    )
+    idx = int(np.where(match)[0][0])
+    assert idx > 0
+    assert results_with[0].data["Time [s]"][0] == full_data["Time [s]"][idx - 1]
+
+
+def test_iter_rest_with_include_preceding_point(BreakinCycles_fixture):
+    """Test iter_rest with include_preceding_point."""
+    cycle0 = BreakinCycles_fixture.cycle(0)
+    results_without = list(cycle0.iter_rest(slice(0, 1)))
+    results_with = list(cycle0.iter_rest(slice(0, 1), include_preceding_point=True))
+
+    assert len(results_with) == len(results_without)
+    assert len(results_with[0].data) == len(results_without[0].data) + 1
+    c0_data = cycle0.data
+    first_row = results_without[0].data
+    match = (
+        (c0_data["Time [s]"] == first_row["Time [s]"][0])
+        & (c0_data["Step"] == first_row["Step"][0])
+        & (c0_data["Event"] == first_row["Event"][0])
+    )
+    idx = int(np.where(match)[0][0])
+    assert idx > 0
+    assert results_with[0].data["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
+
+
+def test_iter_chargeordischarge_with_include_preceding_point(BreakinCycles_fixture):
+    """Test iter_chargeordischarge with include_preceding_point."""
+    cycle0 = BreakinCycles_fixture.cycle(0)
+    # Use index 1 in cycle 0 to ensure a predecessor exists
+    results_without = list(cycle0.iter_chargeordischarge(slice(1, 2)))
+    results_with = list(
+        cycle0.iter_chargeordischarge(slice(1, 2), include_preceding_point=True)
+    )
+
+    assert len(results_with) == len(results_without)
+    assert len(results_with[0].data) == len(results_without[0].data) + 1
+    c0_data = cycle0.data
+    first_row = results_without[0].data
+    match = (
+        (c0_data["Time [s]"] == first_row["Time [s]"][0])
+        & (c0_data["Step"] == first_row["Step"][0])
+        & (c0_data["Event"] == first_row["Event"][0])
+    )
+    idx = int(np.where(match)[0][0])
+    assert idx > 0
+    assert results_with[0].data["Time [s]"][0] == c0_data["Time [s]"][idx - 1]
+
+
+def test_iter_cycle_with_include_preceding_point(BreakinCycles_fixture):
+    """Test iter_cycle with include_preceding_point on cycle 1."""
+    results_without = list(BreakinCycles_fixture.iter_cycle(slice(1, 2)))
+    results_with = list(
+        BreakinCycles_fixture.iter_cycle(slice(1, 2), include_preceding_point=True)
+    )
+
+    assert len(results_with) == len(results_without)
+    assert len(results_with[0].data) == len(results_without[0].data) + 1
+    full_data = BreakinCycles_fixture.data
+    first_row = results_without[0].data
+    match = (
+        (full_data["Time [s]"] == first_row["Time [s]"][0])
+        & (full_data["Step"] == first_row["Step"][0])
+        & (full_data["Event"] == first_row["Event"][0])
+    )
+    idx = int(np.where(match)[0][0])
+    assert idx > 0
+    assert results_with[0].data["Time [s]"][0] == full_data["Time [s]"][idx - 1]
+
+
+@pytest.mark.parametrize("exp_name", ["Break-in Cycles", "Discharge Pulses"])
+def test_procedure_experiment_with_include_preceding_point(procedure_fixture, exp_name):
+    """Test Procedure.experiment with include_preceding_point."""
+    data_without = procedure_fixture.experiment(exp_name).data
+    data_with = procedure_fixture.experiment(
+        exp_name, include_preceding_point=True
+    ).data
+
+    assert len(data_with) == len(data_without) + 1
+    full_data = procedure_fixture.data
+    match = (
+        (full_data["Time [s]"] == data_without["Time [s]"][0])
+        & (full_data["Step"] == data_without["Step"][0])
+        & (full_data["Event"] == data_without["Event"][0])
+    )
+    idx = int(np.where(match)[0][0])
+    assert idx > 0
+    assert data_with["Time [s]"][0] == full_data["Time [s]"][idx - 1]
+
+
+def test_negative_step_in_slice_raises_error(BreakinCycles_fixture):
+    """Test that negative step in slice raises ValueError."""
+    with pytest.raises(ValueError, match="Negative step is not supported"):
+        BreakinCycles_fixture.cycle(0).step(slice(3, 0, -1)).data
+
+
+def test_multiple_indices_in_build_mask(BreakinCycles_fixture):
+    """Test _build_mask with multiple indices."""
+    data = BreakinCycles_fixture.cycle(0).step(0, 1, 2).data
+    step_values = sorted(data["Step"].unique().to_list())
+    assert step_values == [4, 5, 6]
+
+
+def test_multiple_indices_with_range_and_slice(BreakinCycles_fixture):
+    """Test multiple indices combining range and slice."""
+    data = BreakinCycles_fixture.cycle(0).step(0, slice(2, 4)).data
+    step_values = set(data["Step"].unique().to_list())
+    assert step_values == {4, 6, 7}
+
+
 @pytest.fixture
 def generic_experiment():
-    """Return a generic filter."""
-    steps = [
-        0,
-        0,
-        1,
-        1,
-        1,
-        0,
-        0,
-        1,
-        1,
-        1,
-        0,
-        0,
-        1,
-        1,
-        1,
-        0,
-        0,
-        1,
-        1,
-        1,
-        2,
-        2,
-        2,
-        2,
-        3,
-        3,
-        0,
-        0,
-        1,
-        1,
-        1,
-        0,
-        0,
-        1,
-        1,
-        1,
-        0,
-        0,
-        1,
-        1,
-        1,
-        0,
-        0,
-        1,
-        1,
-        1,
-        2,
-        2,
-        2,
-        2,
-        3,
-        3,
-    ]
+    """Return a generic experiment for testing nested cycles."""
+    # Outer cycle: Step 1, 2, 1, 2, 3, 4 (26 rows)
+    # Inner cycle: Step 1, 2
+    # 2 outer cycles total = 52 rows
+
+    # One outer cycle block:
+    # Step 1: 3 rows, Step 2: 3 rows
+    # Step 1: 3 rows, Step 2: 3 rows
+    # Step 3: 10 rows, Step 4: 4 rows
+    outer_steps = [1] * 3 + [2] * 3 + [1] * 3 + [2] * 3 + [3] * 10 + [4] * 4
+    steps = outer_steps * 2
+
+    events = []
+    # 6 steps per outer cycle * 2 outer cycles = 12 events
+    event_counts = [3, 3, 3, 3, 10, 4] * 2
+    for i, count in enumerate(event_counts):
+        events.extend([i] * count)
+
+    currents = []
+    for _ in range(2):
+        currents.extend([1.0] * 3)  # CC Charge
+        currents.extend([0.5, 0.2, 0.1])  # CV Charge
+        currents.extend([1.0] * 3)  # CC Charge
+        currents.extend([0.5, 0.2, 0.1])  # CV Charge
+        currents.extend([-1.0] * 10)  # Discharge
+        currents.extend([0.0] * 4)  # Rest
+
+    voltages = []
+    for _ in range(2):
+        voltages.extend([3.0, 3.3, 3.6])  # CC Charge
+        voltages.extend([4.2, 4.2, 4.2])  # CV Charge
+        voltages.extend([3.0, 3.3, 3.6])  # CC Charge
+        voltages.extend([4.2, 4.2, 4.2])  # CV Charge
+        voltages.extend([4.0, 3.7, 3.5, 3.2, 3.0, 4.0, 3.7, 3.5, 3.2, 3.0])
+        voltages.extend([3.0] * 4)  # Rest
+
     dataframe = pl.DataFrame(
         {
             "Time [s]": list(range(len(steps))),
             "Step": steps,
-            "Event": list(range(len(steps))),
-            "Current [A]": steps,
-            "Voltage [V]": steps,
-            "Capacity [Ah]": steps,
+            "Event": events,
+            "Current [A]": currents,
+            "Voltage [V]": voltages,
+            "Capacity [Ah]": [0.0] * len(steps),
         },
     )
-    info = {}
     step_descriptions = {
-        "Step": [0, 1, 2, 3],
-        "Description": ["Charge", "Discharge", "Charge", "Discharge"],
+        "Step": [1, 2, 3, 4],
+        "Description": ["CC Charge", "CV Charge", "Discharge", "Rest"],
     }
 
-    cycle_info = [(0, 3, 2), (0, 1, 2)]
+    # Outer cycle ends on Step 4; Inner cycle ends on Step 2
+    cycle_info = [(1, 4, 2), (1, 2, 2)]
     return filters.Experiment(
         lf=dataframe,
-        info=info,
+        info={},
         step_descriptions=step_descriptions,
         cycle_info=cycle_info,
     )
 
 
 def test_cycle_generic(generic_experiment):
-    """Test the cycle method."""
-    assert generic_experiment.cycle_info == [(0, 3, 2), (0, 1, 2)]
-    assert filters._cycle(generic_experiment, 0).data[
-        "Time [s]"
-    ].unique().to_list() == list(range(26))
-    assert filters._cycle(generic_experiment, 1).data[
-        "Time [s]"
-    ].unique().to_list() == list(range(26, 52))
-    assert filters._cycle(generic_experiment, -1).data[
-        "Time [s]"
-    ].unique().to_list() == list(range(26, 52))
-
-    next_cycle = filters._cycle(generic_experiment, 1)
-    assert next_cycle.cycle_info == [(0, 1, 2)]
-    assert filters._cycle(next_cycle, 0).data["Time [s]"].unique().to_list() == list(
-        range(26, 31),
-    )
-    assert filters._cycle(next_cycle, 3).data["Time [s]"].unique().to_list() == list(
-        range(41, 46),
-    )
-    assert filters._cycle(next_cycle, -1).data["Time [s]"].unique().to_list() == list(
-        range(46, 52),
+    """Test cycle filtering on the generic synthetic experiment."""
+    # Outer cycles (each 26 rows)
+    assert generic_experiment.cycle(0).data["Time [s]"].to_list() == list(range(26))
+    assert generic_experiment.cycle(1).data["Time [s]"].to_list() == list(range(26, 52))
+    assert generic_experiment.cycle(-1).data["Time [s]"].to_list() == list(
+        range(26, 52)
     )
 
-    # test when cycle numbers are inferred
+    # Inner cycles
+    next_cycle = generic_experiment.cycle(1)
+    assert next_cycle.cycle_info == [(1, 2, 2)]
+    # Inner cycle 0 of outer cycle 1: rows 26-31
+    assert next_cycle.cycle(0).data["Time [s]"].to_list() == list(range(26, 32))
+    # Inner cycle 1: rows 32-37
+    assert next_cycle.cycle(1).data["Time [s]"].to_list() == list(range(32, 38))
+    # Inner cycle 2 (remaining steps 3 and 4): rows 38-51
+    assert next_cycle.cycle(2).data["Time [s]"].to_list() == list(range(38, 52))
+
+    # Test inferred cycles
     generic_experiment.cycle_info = []
-    assert filters._cycle(generic_experiment, 0).data[
-        "Time [s]"
-    ].unique().to_list() == list(range(5))
-    assert filters._cycle(generic_experiment, -1).data[
-        "Time [s]"
-    ].unique().to_list() == list(range(41, 52))
+    # Step decreases from 2 to 1 at index 6, from 4 to 1 at index 26,
+    # from 2 to 1 at index 32.
+    # Step sequence: 1,1,1,2,2,2, | 1,1,1,2,2,2, | 3,3,3,3,3,3,3,3,3,3,4,4,4,4 | ...
+    # Step decreases at indices 6, 26, 32.
+    assert generic_experiment.cycle(0).data["Time [s]"].to_list() == list(range(6))
+    assert generic_experiment.cycle(1).data["Time [s]"].to_list() == list(range(6, 26))
+    assert generic_experiment.cycle(2).data["Time [s]"].to_list() == list(range(26, 32))
+    assert generic_experiment.cycle(-1).data["Time [s]"].to_list() == list(
+        range(32, 52)
+    )
+
+
+def test_cycle_chaining_generic(generic_experiment):
+    """Test chained cycle filtering on nested cycle_info."""
+    data = generic_experiment.cycle(1).cycle(2).data
+    assert data["Time [s]"].to_list() == list(range(38, 52))
+
+
+def test_step_generic(generic_experiment):
+    """Test step filtering on the generic synthetic experiment."""
+    # Step groups: 0:[1,1,1], 1:[2,2,2], 2:[1,1,1], 3:[2,2,2], 4:[3...], 5:[4...]
+    # Cycle 2 starts at index 6: 6:[1,1,1], 7:[2,2,2], 8:[1,1,1], 9:[2,2,2],
+    # 10:[3...], 11:[4...]
+
+    data = generic_experiment.step(0).data
+    assert data["Time [s]"].to_list() == [0, 1, 2]
+    assert (data["Step"] == 1).all()
+
+    # step(2) is the second occurrence of Step 1 (rows 6-8)
+    data = generic_experiment.step(2).data
+    assert data["Time [s]"].to_list() == [6, 7, 8]
+
+    # step(6) is the first Step 1 in the second outer cycle (rows 26-28)
+    data = generic_experiment.step(6).data
+    assert data["Time [s]"].to_list() == [26, 27, 28]
+
+    # Multiple steps
+    data = generic_experiment.step(0, 1).data
+    assert data["Time [s]"].to_list() == list(range(6))
+    assert data["Step"].unique().to_list() == [1, 2]
+
+
+def test_charge_generic(generic_experiment):
+    """Test charge filtering on the generic synthetic experiment."""
+    # Step 1 and 2 are charge.
+    # Groups matching Current > 0:
+    # 0:[0-2], 1:[3-5], 2:[6-8], 3:[9-11], 4:[26-28], 5:[29-31], 6:[32-34], 7:[35-37]
+
+    # charge(0) should be event 0 (Step 1, rows 0-2)
+    data = generic_experiment.charge(0).data
+    assert data["Time [s]"].to_list() == [0, 1, 2]
+    assert (data["Step"] == 1).all()
+
+    # charge(1) should be event 1 (Step 2, rows 3-5)
+    data = generic_experiment.charge(1).data
+    assert data["Time [s]"].to_list() == [3, 4, 5]
+    assert (data["Step"] == 2).all()
+
+    # charge(4) should be first Step 1 in second outer cycle (rows 26-28)
+    data = generic_experiment.charge(4).data
+    assert data["Time [s]"].to_list() == [26, 27, 28]
+
+
+def test_discharge_generic(generic_experiment):
+    """Test discharge filtering on the generic synthetic experiment."""
+    # Step 3 is discharge.
+    # Groups matching Current < 0: 0:[12-21], 1:[38-47]
+    data = generic_experiment.discharge(0).data
+    assert data["Time [s]"].to_list() == list(range(12, 22))
+    assert (data["Step"] == 3).all()
+    assert (data["Current [A]"] < 0).all()
+
+    data = generic_experiment.discharge(1).data
+    assert data["Time [s]"].to_list() == list(range(38, 48))
+
+
+def test_rest_generic(generic_experiment):
+    """Test rest filtering on the generic synthetic experiment."""
+    # Step 4 is rest.
+    # Groups matching Current == 0: 0:[22-25], 1:[48-51]
+    data = generic_experiment.rest(0).data
+    assert data["Time [s]"].to_list() == list(range(22, 26))
+    assert (data["Step"] == 4).all()
+    assert (data["Current [A]"] == 0).all()
+
+
+def test_constant_current_generic(generic_experiment):
+    """Test constant_current filtering on the generic synthetic experiment."""
+    data = generic_experiment.constant_current(0, target=1).data
+    assert data["Time [s]"].to_list() == [0, 1, 2]
+    assert (data["Current [A]"] == 1.0).all()
+
+    data = generic_experiment.constant_current(0, target=-1).data
+    assert data["Time [s]"].to_list() == list(range(12, 22))
+    assert (data["Current [A]"] == -1.0).all()
+
+
+def test_constant_voltage_generic(generic_experiment):
+    """Test constant_voltage filtering on the generic synthetic experiment."""
+    data = generic_experiment.constant_voltage(0, target=4.2).data
+    assert data["Time [s]"].to_list() == [3, 4, 5]
+
+
+def test_iter_filters_generic(generic_experiment):
+    """Test iterator versions of filters on generic experiment."""
+    # iter_step: 6 steps per outer cycle * 2 = 12
+    steps = list(generic_experiment.iter_step())
+    assert len(steps) == 12
+
+    # iter_charge: Step 1 and 2 match Current > 0.
+    # (Step 1, Step 2, Step 1, Step 2) * 2 = 8 groups
+    charges = list(generic_experiment.iter_charge())
+    assert len(charges) == 8
+
+    # iter_discharge: Step 3 matches Current < 0.
+    # Step 3 * 2 = 2 groups
+    discharges = list(generic_experiment.iter_discharge())
+    assert len(discharges) == 2
+
+    # iter_rest: Step 4 matches Current == 0.
+    # Step 4 * 2 = 2 groups
+    rests = list(generic_experiment.iter_rest())
+    assert len(rests) == 2
+
+    # iter_chargeordischarge: Step 1, 2, 3 match abs(Current) > 0.
+    # (Step 1, Step 2, Step 1, Step 2, Step 3) * 2 = 10 groups
+    cods = list(generic_experiment.iter_chargeordischarge())
+    assert len(cods) == 10
 
 
 def _make_multilevel_experiment(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -130,17 +130,17 @@ class TestExtendMaskWithPrecedingPoint:
     @pytest.mark.parametrize(
         "input_mask, expected_mask",
         [
-            (
+            (  # mid-run: preceding row added before the True block
                 [False, False, True, True, False, False],
                 [False, True, True, True, False, False],
             ),
-            (
+            (  # leading run: no preceding row to add
                 [True, True, False, False, False, False],
                 [True, True, False, False, False, False],
             ),
-            ([False] * 6, [False] * 6),
-            ([True] * 6, [True] * 6),
-            (
+            ([False] * 6, [False] * 6),  # all False: no change
+            ([True] * 6, [True] * 6),  # all True: no change
+            (  # two separate runs: each gains its preceding row
                 [False, True, False, False, True, False],
                 [True, True, False, True, True, False],
             ),
@@ -161,19 +161,20 @@ class TestMakeGroupMarkerExpr:
     @pytest.mark.parametrize(
         "condition, expected_markers",
         [
-            (
+            (  # single matching group: only its first row marked
                 pl.col("Current [A]") > 0,
                 [True, False, False, False, False, False, False, False],
             ),
-            (
+            (  # single matching group at non-zero position
                 pl.col("Current [A]") < 0,
                 [False, False, False, False, True, False, False, False],
             ),
-            (
+            (  # two non-contiguous matching groups: two markers
                 pl.col("Current [A]") == 0,
                 [False, False, True, False, False, False, True, False],
             ),
-            (pl.lit(False), [False] * 8),
+            (pl.lit(False), [False] * 8),  # no matches: no markers
+            # every group matches: first row of each event marked
             (pl.lit(True), [True, False, True, False, True, False, True, False]),
         ],
     )
@@ -198,10 +199,10 @@ class TestCountConditionGroups:
     @pytest.mark.parametrize(
         "condition, expected_count",
         [
-            (None, 4),
-            (pl.col("Current [A]") > 0, 1),
-            (pl.col("Current [A]") == 0, 2),
-            (pl.col("Current [A]") < 0, 1),
+            (None, 4),  # no condition: counts all distinct event groups
+            (pl.col("Current [A]") > 0, 1),  # one positive-current group
+            (pl.col("Current [A]") == 0, 2),  # two zero-current groups
+            (pl.col("Current [A]") < 0, 1),  # one negative-current group
         ],
     )
     def test_count_condition_groups_counts_correctly(self, condition, expected_count):
@@ -222,18 +223,21 @@ class TestSliceToMaskExpr:
     @pytest.mark.parametrize(
         "sl, expected_values",
         [
-            (slice(2, 5), [2, 3, 4]),
-            (slice(None, 3), [0, 1, 2]),
-            (slice(7, None), [7, 8, 9]),
-            (slice(-3, None), [7, 8, 9]),
-            (slice(None, -2), [0, 1, 2, 3, 4, 5, 6, 7]),
-            (slice(-5, -2), [5, 6, 7]),
-            (slice(0, 10, 2), [0, 2, 4, 6, 8]),
-            (slice(3, 0), []),
-            (slice(-3, 0), [7, 8, 9]),
-            (slice(-5, None, 2), [5, 7, 9]),
-            (slice(-5, -1, 2), [5, 7]),
-            (slice(None, None), list(range(10))),
+            (slice(2, 5), [2, 3, 4]),  # positive start and stop
+            (slice(None, 3), [0, 1, 2]),  # no start: from beginning
+            (slice(7, None), [7, 8, 9]),  # no stop: to end
+            (slice(-3, None), [7, 8, 9]),  # negative start: from 3rd-to-last
+            (
+                slice(None, -2),
+                [0, 1, 2, 3, 4, 5, 6, 7],
+            ),  # negative stop: exclude last 2  # noqa: E501
+            (slice(-5, -2), [5, 6, 7]),  # negative start and stop
+            (slice(0, 10, 2), [0, 2, 4, 6, 8]),  # step > 1 with positive bounds
+            (slice(3, 0), []),  # stop < start: empty
+            (slice(-3, 0), [7, 8, 9]),  # negative start + stop=0: open-ended
+            (slice(-5, None, 2), [5, 7, 9]),  # negative start + step > 1
+            (slice(-5, -1, 2), [5, 7]),  # negative bounds + step > 1
+            (slice(None, None), list(range(10))),  # no bounds: all rows
         ],
     )
     def test_slice_to_mask_selects_correct_values(self, sl, expected_values):
@@ -273,17 +277,33 @@ class TestFilterBuildMask:
     @pytest.mark.parametrize(
         "filt, indices, expected_events",
         [
+            # no indices: all groups selected
             (filters._Filter("Event"), (), [0, 0, 1, 1, 2, 2, 3, 3]),
+            # first group by positive index
             (filters._Filter("Event"), (0,), [0, 0]),
+            # last group by negative index
             (filters._Filter("Event"), (-1,), [3, 3]),
+            # range selects first two groups
             (filters._Filter("Event"), (range(0, 2),), [0, 0, 1, 1]),
+            # slice selects groups 1-2
             (filters._Filter("Event"), (slice(1, 3),), [1, 1, 2, 2]),
+            # condition, no indices: all matching groups
             (filters._Filter("Event", pl.col("Current [A]") > 0), (), [0, 0]),
+            # condition, first matching group
             (filters._Filter("Event", pl.col("Current [A]") > 0), (0,), [0, 0]),
+            # condition with two matches, no indices
             (filters._Filter("Event", pl.col("Current [A]") == 0), (), [1, 1, 3, 3]),
+            # condition, first of two matching groups
             (filters._Filter("Event", pl.col("Current [A]") == 0), (0,), [1, 1]),
+            # condition, second matching group by positive index
             (filters._Filter("Event", pl.col("Current [A]") == 0), (1,), [3, 3]),
+            # range with negative bounds: last two groups
+            (filters._Filter("Event"), (range(-2, 0),), [2, 2, 3, 3]),
+            # condition + negative index: last matching group
+            (filters._Filter("Event", pl.col("Current [A]") == 0), (-1,), [3, 3]),
+            # unsupported index type falls back to all groups (no condition)
             (filters._Filter("Event"), ("unsupported",), [0, 0, 1, 1, 2, 2, 3, 3]),
+            # unsupported index type falls back to all matching groups (with condition)
             (
                 filters._Filter("Event", pl.col("Current [A]") > 0),
                 ("unsupported",),
@@ -311,9 +331,9 @@ class TestFilterExpandPositions:
     @pytest.mark.parametrize(
         "indices, expected_positions",
         [
-            ((), [0, 1, 2, 3]),
-            ((0, 1), [0, 1]),
-            ((slice(-2, None),), [2, 3]),
+            ((), [0, 1, 2, 3]),  # no indices: all positions
+            ((0, 1), [0, 1]),  # two explicit positive indices
+            ((slice(-2, None),), [2, 3]),  # slice with negative start
         ],
     )
     def test_filter_expand_positions_resolves_to_integers(


### PR DESCRIPTION
## Summary

Refactors filter architecture using a private Filter class with mixin-based filtering methods, adds parametric constant-value filtering with `target` and `rtol` parameters, introduces `include_preceding_point` option across all filter methods, and fixes cycling summary result ordering. Closes #374, #363 

## Features

- Add `target` and `rtol` parameters to `constant_voltage()` and `constant_current()` for explicit constant-value matching with configurable tolerance ([946623e1](https://github.com/ImperialCollegeLondon/PyProBE/commit/946623e1))
- Add `include_preceding_point` parameter to all filter methods across Procedure, Experiment, Cycle, and Step to optionally include the row before each selected group ([ae3abcfc](https://github.com/ImperialCollegeLondon/PyProBE/commit/ae3abcfc))

## Refactoring

- Introduce private `_Filter` class encapsulating group-filtering logic with `_build_mask()`, `_expand_positions()`, and helper utilities ([ae3abcfc](https://github.com/ImperialCollegeLondon/PyProBE/commit/ae3abcfc))
  - Add mixin-based filter methods (CycleFiltersMixin, StepFiltersMixin) for cleaner separation of concerns ([ae3abcfc](https://github.com/ImperialCollegeLondon/PyProBE/commit/ae3abcfc))
  - Minor docstring updates and method refinements ([a0bf7844](https://github.com/ImperialCollegeLondon/PyProBE/commit/a0bf7844))
  - Make `Filter` class private with final API cleanup ([81a47237](https://github.com/ImperialCollegeLondon/PyProBE/commit/81a47237))

## Fixes

- Sort cycling summary results by Cycle column before returning to ensure consistent ordering ([c3945a54](https://github.com/ImperialCollegeLondon/PyProBE/commit/c3945a54))

## Tests

- Expand filter test coverage including slice behavior, `include_preceding_point` assertions, iterator coverage, and nested cycle chaining ([29af1578](https://github.com/ImperialCollegeLondon/PyProBE/commit/29af1578))
- Restructure filter tests module for improved organization ([a8edaf5b](https://github.com/ImperialCollegeLondon/PyProBE/commit/a8edaf5b))

## Docs

- Add examples for new filter functionality including parametric constant-value and `include_preceding_point` features ([1033f7d4](https://github.com/ImperialCollegeLondon/PyProBE/commit/1033f7d4))

## Chores

- Update gitignore and pre-commit ruff configuration